### PR TITLE
chore(deps): bump cpal from 0.17.3 to 0.18.1

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -720,14 +720,15 @@ dependencies = [
 
 [[package]]
 name = "cpal"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
+checksum = "5f77b11176c37874be37e8d691c946e31b2b8c357abce9526f6a99eb469e1028"
 dependencies = [
  "alsa",
+ "block2",
  "coreaudio-rs",
  "dasp_sample",
- "jni",
+ "jni 0.22.4",
  "js-sys",
  "libc",
  "mach2",
@@ -742,10 +743,9 @@ dependencies = [
  "objc2-core-audio-types",
  "objc2-core-foundation",
  "objc2-foundation",
- "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
  "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2190,6 +2190,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2357,12 +2387,9 @@ dependencies = [
 
 [[package]]
 name = "mach2"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
-dependencies = [
- "libc",
-]
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "markup5ever"
@@ -2645,6 +2672,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
 dependencies = [
+ "bitflags 2.13.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -4011,6 +4039,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4235,7 +4273,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -4309,7 +4347,7 @@ dependencies = [
  "heck 0.5.0",
  "http",
  "image",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -4530,7 +4568,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -4553,7 +4591,7 @@ checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -6085,7 +6123,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,7 @@ log = "0.4"
 tauri = { version = "2.11.1", features = ["tray-icon", "image-png"] }
 tauri-plugin-store = "2.4.3"
 tauri-plugin-log = "2"
-cpal = "0.17.3"
+cpal = "0.18.1"
 realfft = "3.4.0"
 rustfft = "6.2.0"
 sha2 = "0.11"

--- a/src-tauri/src/audio/cpal_backend.rs
+++ b/src-tauri/src/audio/cpal_backend.rs
@@ -375,7 +375,7 @@ pub(crate) fn run_meter_pipeline_bridge_thread(
 fn create_silence_stream(device: &cpal::Device, config: &StreamConfig) -> Option<cpal::Stream> {
   let stream = device
     .build_output_stream(
-      config,
+      *config,
       move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
         // Write silence (all zeros)
         for sample in data.iter_mut() {
@@ -464,7 +464,7 @@ fn run_capture_worker(args: RunCaptureArgs) -> Result<(), String> {
       let pool = pcm_pool.clone();
       device
         .build_input_stream(
-          &stream_config,
+          stream_config,
           move |data: &[f32], _: &cpal::InputCallbackInfo| {
             if let Some(buffer) = copy_f32_pcm_to_pooled_buffer(&pool, data, &dropped) {
               send_pcm_buffer_or_count_drop(&tx, &pool, buffer, &dropped);
@@ -481,7 +481,7 @@ fn run_capture_worker(args: RunCaptureArgs) -> Result<(), String> {
       let pool = pcm_pool.clone();
       device
         .build_input_stream(
-          &stream_config,
+          stream_config,
           move |data: &[i16], _: &cpal::InputCallbackInfo| {
             if let Some(buffer) = copy_i16_pcm_to_pooled_buffer(&pool, data, &dropped) {
               send_pcm_buffer_or_count_drop(&tx, &pool, buffer, &dropped);
@@ -498,7 +498,7 @@ fn run_capture_worker(args: RunCaptureArgs) -> Result<(), String> {
       let pool = pcm_pool.clone();
       device
         .build_input_stream(
-          &stream_config,
+          stream_config,
           move |data: &[u16], _: &cpal::InputCallbackInfo| {
             if let Some(buffer) = copy_u16_pcm_to_pooled_buffer(&pool, data, &dropped) {
               send_pcm_buffer_or_count_drop(&tx, &pool, buffer, &dropped);

--- a/src-tauri/src/audio/device_enum.rs
+++ b/src-tauri/src/audio/device_enum.rs
@@ -45,7 +45,6 @@ pub(crate) fn device_list_label(device: &cpal::Device) -> Result<String, String>
   let primary = d.name().trim();
   let parts: Vec<&str> = d
     .extended()
-    .iter()
     .map(|s| s.trim())
     .filter(|s| !s.is_empty())
     .collect();


### PR DESCRIPTION
Supersedes #164. Dependabot's bump failed to build because cpal 0.18 has breaking API changes; this PR includes the bump **and** the required source adaptations.

## cpal 0.18 breaking changes adapted
- `build_input_stream`/`build_output_stream` now take `StreamConfig` **by value** instead of by reference (`StreamConfig` is `Copy`, so we pass it directly — no clone).
- `DeviceDescription::extended()` now returns an iterator directly rather than a slice, so the `.iter()` call is dropped.

## Verification (local)
- `cargo build` ✅
- `cargo clippy --all-targets` ✅ (no warnings)
- `cargo fmt --check` ✅
- `cargo test` ✅ (88 passed)

Once green, close #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)