### PR TITLE
Add custom themes editor

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,0 +1,85 @@
+# Dev installer builds — manual, for testing only.
+# - Triggered by workflow_dispatch on any branch (driven by the plvs-dev-build skill).
+# - Builds the Windows NSIS installer + portable exe for the selected ref.
+# - Publishes to a single rolling "dev" Pre-release (overwritten each run).
+# - Does NOT bump the version, touch CHANGELOG, or create a v* tag — this is
+#   not an official release. See release.yml + the plvs-release skill for that.
+
+name: Dev Build
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# Only one dev build at a time; a newer run supersedes the older.
+concurrency:
+  group: dev-build
+  cancel-in-progress: true
+
+jobs:
+  build-windows-dev:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.19.0"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend (Vite)
+        run: npm run build
+
+      - name: Build Tauri bundle (NSIS + release binary for portable)
+        run: npm run desktop:release-nsis
+
+      - name: Stage dev installers (filename marked -dev.<short-sha>)
+        id: stage
+        shell: pwsh
+        run: |
+          $ver = (Get-Content package.json -Raw | ConvertFrom-Json).version
+          $sha = "${{ github.sha }}".Substring(0, 7)
+          $label = "$ver-dev.$sha"
+          New-Item -ItemType Directory -Force dev-dist | Out-Null
+          $nsis = Get-ChildItem src-tauri/target/release/bundle/nsis/*.exe | Select-Object -First 1
+          if (-not $nsis) { throw "NSIS installer not found" }
+          Copy-Item $nsis.FullName "dev-dist/PLVS_${label}_x64-setup.exe"
+          Copy-Item "src-tauri/target/release/plvs.exe" "dev-dist/PLVS-v${label}-x64-portable.exe"
+          "label=$label" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Remove previous dev pre-release
+        shell: pwsh
+        continue-on-error: true
+        run: gh release delete dev --yes --cleanup-tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish rolling dev pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: dev
+          target_commitish: ${{ github.sha }}
+          name: "Dev build ${{ steps.stage.outputs.label }}"
+          prerelease: true
+          body: |
+            Unofficial development build — for testing only, **not** an official release.
+
+            - Branch: `${{ github.ref_name }}`
+            - Commit: ${{ github.sha }}
+
+            This Pre-release is rolling: every dev build overwrites it, so it
+            always holds the latest build only.
+          files: dev-dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.trae/skills/plvs-dev-build/SKILL.md
+++ b/.trae/skills/plvs-dev-build/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: "plvs-dev-build"
+description: "Builds an unofficial dev/preview installer for PLVS from the current branch and publishes it to a rolling GitHub Pre-release. Invoke when the user wants a dev build, preview build, or test installer — NOT for official releases (use plvs-release for those)."
+---
+
+# PLVS Dev Build Skill
+
+Produces a throwaway **dev installer** for testing, downloadable from GitHub.
+It builds whatever branch you point it at, marks the artifacts with a
+`-dev.<short-sha>` suffix, and publishes them to a single rolling `dev`
+Pre-release.
+
+## When to Invoke
+
+- User wants a dev / preview / nightly / test installer
+- User wants to hand someone a build of a work-in-progress branch
+- User wants to download an installer of the current branch from GitHub
+
+## NOT for official releases
+
+This skill is intentionally separate from `plvs-release`:
+
+| | `plvs-dev-build` (this) | `plvs-release` |
+|---|---|---|
+| Version | unchanged; `-dev.<sha>` in filename only | bumped `X.Y.Z`, synced 3 places |
+| CHANGELOG | untouched | new section required |
+| Git tag | none (rolling `dev` tag, auto-managed) | permanent `vX.Y.Z` |
+| GitHub Release | **Pre-release**, overwritten each build | normal Release, kept forever |
+| Platforms | **Windows only** | Windows + macOS |
+| Preflight gate | **skipped** (fast, unverified) | full `npm run check` gate |
+
+If the user means to ship a real version, stop and use `plvs-release` instead.
+
+## How It Works
+
+The build runs in CI — workflow `.github/workflows/dev-build.yml`, triggered
+manually via `workflow_dispatch`. It checks out the ref you pass, builds the
+NSIS installer + portable exe, then **replaces** the `dev` Pre-release so it
+always holds only the latest build. The verify/lint/test gate is skipped, so
+dev builds are fast but unverified — a green run only means it compiled.
+
+## Steps
+
+### 1. Confirm the branch and push it
+
+CI builds a ref that exists on `origin`, so the commit you want **must be
+pushed first**.
+
+```bash
+git branch --show-current        # the branch that will be built
+git status --porcelain           # warn if there are uncommitted changes
+git push                         # ensure origin has the commit to build
+```
+
+If there are uncommitted changes, tell the user the dev build will reflect
+the **last pushed commit**, not their working tree — commit + push first, or
+proceed knowingly.
+
+### 2. Trigger the dev build
+
+```bash
+git rev-parse --abbrev-ref HEAD                 # <branch>
+gh workflow run dev-build.yml --ref <branch>
+```
+
+### 3. Watch the run
+
+```bash
+gh run list --workflow=dev-build.yml --limit 1
+gh run watch <run-id>            # or open the Actions URL it prints
+```
+
+### 4. Hand back the download link
+
+On success, the installer is on the rolling Pre-release:
+
+```bash
+gh release view dev --web        # opens it in the browser
+```
+
+Give the user the page URL (`<repo>/releases/tag/dev`) and the asset names:
+
+| Artifact | Filename |
+|----------|----------|
+| Installer | `PLVS_<version>-dev.<short-sha>_x64-setup.exe` |
+| Portable | `PLVS-v<version>-dev.<short-sha>-x64-portable.exe` |
+
+The `<short-sha>` lets a tester tell two dev builds apart even after download.
+
+## Notes
+
+- **Rolling, single build only.** Each run overwrites the `dev` Pre-release;
+  earlier dev installers are gone. It's for "test the latest", not history.
+- **No version collision.** The version number in `package.json` is never
+  touched; the `-dev.<sha>` marker lives only in the artifact filenames.
+- **Unsigned**, like official builds — testers will see SmartScreen warnings.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ PLVS：实时音频计量桌面应用（Tauri 2 + Rust 后端 / React 19 + Vite 
 - 测试与源文件同目录，命名 `*.test.js` / `*.test.jsx`（Vitest）。
 
 ## 工作流偏好
-- 纯文档改动直接提交 main，不开 feature 分支。
 - 回复用中文；代码 / 路径 / 术语保持英文。
+- **可以用 subagents（Agent 工具）分担工作**，但省着点 token：仅在任务确实能并行、或需要隔离上下文时才 spawn；琐碎的小活直接自己干，别为省事频繁起 agent。
+  - **按子任务难度选模型**：搜索 / 改字串 / 跑命令这类机械活派便宜模型（Haiku、Sonnet），只有需要复杂推理的子任务才用 Opus。用 Agent 的 `model` 参数指定。
 - **Commit/CL message 不要以 `@` 开头**。根因：Windows PowerShell 下用 here-string `@'...'@` 传多行 message 时，定界符的 `@` 会漏进 subject。改用多个 `-m` 拼 subject 和 body，别用 here-string。

--- a/docs/working/superpowers/plans/2026-06-20-custom-themes-plan-1-foundation.md
+++ b/docs/working/superpowers/plans/2026-06-20-custom-themes-plan-1-foundation.md
@@ -1,0 +1,643 @@
+# Custom Themes — Plan 1: Foundation (model, store, registry, engine wiring)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the theme engine able to store, resolve, and apply user `CustomTheme` objects (persisted in a new `themesStore`), so a custom id selected under `appearance: "fixed"` renders correctly and a deleted/unknown id falls back to `plvs-dark` — all headless, no editor UI yet.
+
+**Architecture:** A `CustomTheme` is a full standalone snapshot shaped like a builtin theme, so it feeds the existing `buildThemeTokens` + shell + colormap path with no special-casing. A small registry (`getTheme`/`isKnownThemeId`) resolves any id (builtin or custom) to its object; `resolveThemeId` and `applyThemeToDocument` take a `customThemes` map; the three apply sites (`main.jsx` boot, `useSettings`, `SpectrogramPanel` colormap) load custom themes from the repo and pass them through.
+
+**Tech Stack:** JavaScript (ESM), React 19, Vitest.
+
+**Spec:** `docs/working/superpowers/specs/2026-06-20-custom-themes-design.md` (§4 model, §5 persistence/resolution).
+
+**Roadmap:** Plan 1 of 2. Plan 2 adds the floating editor, color control, draft semantics, and the Settings create/edit/delete UI. After Plan 1, custom themes can exist and render (seedable via the store) but there is no UI to make or edit them yet.
+
+---
+
+### Task 1: `themesStore` persistence domain
+
+**Files:**
+- Modify: `src/persistence/index.js`
+
+- [ ] **Step 1: Add the store and wire export/reset**
+
+In `src/persistence/index.js`, add after the `presetsStore` declaration:
+
+```javascript
+export const themesStore = createDomainStore({ name: "plvs:themes", backend });
+```
+
+Add `themes: themesStore.export()` to the object returned by `exportAll()`, and
+`themesStore.reset();` to `resetAll()`.
+
+- [ ] **Step 2: Verify nothing else broke**
+
+Run: `npx vitest run src/persistence`
+Expected: PASS (existing persistence tests unaffected).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/persistence/index.js
+git commit -m "feat(persistence): add themesStore domain for custom themes"
+```
+
+---
+
+### Task 2: `CustomTheme` model helpers
+
+**Files:**
+- Create: `src/theme/customTheme.js`
+- Test: `src/theme/customTheme.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+import { describe, it, expect } from "vitest";
+import {
+  CUSTOM_THEME_ID_PREFIX,
+  isCustomThemeId,
+  makeCustomThemeFromBase,
+  normalizeCustomTheme,
+} from "./customTheme.js";
+import { BUILTIN_THEMES } from "./builtinThemes.js";
+
+describe("isCustomThemeId", () => {
+  it("is true only for the custom prefix", () => {
+    expect(isCustomThemeId("custom-abc")).toBe(true);
+    expect(isCustomThemeId("plvs-dark")).toBe(false);
+    expect(isCustomThemeId(null)).toBe(false);
+  });
+});
+
+describe("makeCustomThemeFromBase", () => {
+  it("snapshots seeds/semantic/colormap/colorScheme from the base with a new id and name", () => {
+    const base = BUILTIN_THEMES["plvs-dark"];
+    const t = makeCustomThemeFromBase(base, "Sunset", () => "custom-fixed");
+    expect(t.id).toBe("custom-fixed");
+    expect(t.name).toBe("Sunset");
+    expect(t.colorScheme).toBe("dark");
+    expect(t.seeds.accent).toBe(base.seeds.accent);
+    expect(t.seeds).not.toBe(base.seeds); // deep copy
+    expect(t.semantic).toEqual(base.semantic);
+    expect(t.semantic).not.toBe(base.semantic);
+    expect(t.colormap).toEqual(base.colormap);
+  });
+});
+
+describe("normalizeCustomTheme", () => {
+  it("returns the theme for a valid object", () => {
+    const base = BUILTIN_THEMES["plvs-light"];
+    const t = makeCustomThemeFromBase(base, "Mine", () => "custom-1");
+    expect(normalizeCustomTheme(t)).toEqual(t);
+  });
+  it("returns null for invalid input", () => {
+    expect(normalizeCustomTheme(null)).toBeNull();
+    expect(normalizeCustomTheme({ id: "plvs-dark" })).toBeNull(); // not a custom id
+    expect(normalizeCustomTheme({ id: "custom-x" })).toBeNull(); // missing fields
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** — `npx vitest run src/theme/customTheme.test.js` (module not found).
+
+- [ ] **Step 3: Implement `src/theme/customTheme.js`**
+
+```javascript
+export const CUSTOM_THEME_ID_PREFIX = "custom-";
+
+/** @param {unknown} id */
+export function isCustomThemeId(id) {
+  return typeof id === "string" && id.startsWith(CUSTOM_THEME_ID_PREFIX);
+}
+
+const defaultMakeId = () => `${CUSTOM_THEME_ID_PREFIX}${crypto.randomUUID()}`;
+
+/**
+ * Snapshot a builtin or custom theme into a new editable CustomTheme.
+ * @param {{colorScheme:string, seeds:object, semantic:object, colormap:unknown}} base
+ * @param {string} name
+ * @param {() => string} [makeId]
+ */
+export function makeCustomThemeFromBase(base, name, makeId = defaultMakeId) {
+  return {
+    id: makeId(),
+    name: String(name),
+    colorScheme: base.colorScheme === "light" ? "light" : "dark",
+    seeds: {
+      accent: base.seeds.accent,
+      accentSecondary: base.seeds.accentSecondary,
+      signal: {
+        good: base.seeds.signal.good,
+        warn: base.seeds.signal.warn,
+        bad: base.seeds.signal.bad,
+      },
+    },
+    semantic: { ...base.semantic },
+    colormap: structuredClone(base.colormap),
+  };
+}
+
+function isNonEmptyString(v) {
+  return typeof v === "string" && v.length > 0;
+}
+
+/**
+ * Validate a persisted custom theme; return it (as-is) or null if malformed.
+ * @param {unknown} raw
+ */
+export function normalizeCustomTheme(raw) {
+  if (!raw || typeof raw !== "object") return null;
+  const t = /** @type {any} */ (raw);
+  if (!isCustomThemeId(t.id) || !isNonEmptyString(t.name)) return null;
+  if (t.colorScheme !== "dark" && t.colorScheme !== "light") return null;
+  const s = t.seeds;
+  if (!s || typeof s !== "object") return null;
+  if (!isNonEmptyString(s.accent) || !isNonEmptyString(s.accentSecondary)) return null;
+  if (!s.signal || !isNonEmptyString(s.signal.good) || !isNonEmptyString(s.signal.warn) || !isNonEmptyString(s.signal.bad))
+    return null;
+  if (!t.semantic || typeof t.semantic !== "object") return null;
+  if (!Array.isArray(t.colormap)) return null;
+  return t;
+}
+```
+
+- [ ] **Step 4: Run, expect PASS** — `npx vitest run src/theme/customTheme.test.js`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/theme/customTheme.js src/theme/customTheme.test.js
+git commit -m "feat(theme): add CustomTheme model helpers"
+```
+
+---
+
+### Task 3: `customThemesRepo` (CRUD over `themesStore`)
+
+**Files:**
+- Create: `src/theme/customThemesRepo.js`
+- Test: `src/theme/customThemesRepo.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+import { describe, it, expect, beforeEach } from "vitest";
+import { themesStore } from "../persistence/index.js";
+import { makeCustomThemeFromBase } from "./customTheme.js";
+import { BUILTIN_THEMES } from "./builtinThemes.js";
+import {
+  listCustomThemes,
+  listCustomThemesOrdered,
+  upsertCustomTheme,
+  removeCustomTheme,
+} from "./customThemesRepo.js";
+
+function mk(id, name = "T") {
+  return makeCustomThemeFromBase(BUILTIN_THEMES["plvs-dark"], name, () => id);
+}
+
+beforeEach(() => themesStore.reset());
+
+describe("customThemesRepo", () => {
+  it("upserts and lists themes", () => {
+    upsertCustomTheme(mk("custom-a", "A"));
+    upsertCustomTheme(mk("custom-b", "B"));
+    expect(Object.keys(listCustomThemes())).toEqual(["custom-a", "custom-b"]);
+    expect(listCustomThemesOrdered().map((t) => t.id)).toEqual(["custom-a", "custom-b"]);
+  });
+  it("updates in place without reordering", () => {
+    upsertCustomTheme(mk("custom-a", "A"));
+    upsertCustomTheme(mk("custom-b", "B"));
+    upsertCustomTheme(mk("custom-a", "A2"));
+    expect(listCustomThemesOrdered().map((t) => t.name)).toEqual(["A2", "B"]);
+  });
+  it("removes a theme from map and order", () => {
+    upsertCustomTheme(mk("custom-a"));
+    upsertCustomTheme(mk("custom-b"));
+    removeCustomTheme("custom-a");
+    expect(listCustomThemesOrdered().map((t) => t.id)).toEqual(["custom-b"]);
+  });
+  it("drops malformed persisted entries from listings", () => {
+    themesStore.patch({ themes: { "custom-x": { id: "custom-x" } }, order: ["custom-x"] });
+    expect(listCustomThemes()).toEqual({});
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** — `npx vitest run src/theme/customThemesRepo.test.js`.
+
+- [ ] **Step 3: Implement `src/theme/customThemesRepo.js`**
+
+```javascript
+import { themesStore } from "../persistence/index.js";
+import { normalizeCustomTheme } from "./customTheme.js";
+
+function readState() {
+  const raw = themesStore.read();
+  const themes = raw && typeof raw.themes === "object" && raw.themes ? raw.themes : {};
+  const order = Array.isArray(raw && raw.order) ? raw.order : [];
+  return { themes, order };
+}
+
+/** @returns {Record<string, object>} valid custom themes keyed by id */
+export function listCustomThemes() {
+  const { themes } = readState();
+  /** @type {Record<string, object>} */
+  const out = {};
+  for (const [id, t] of Object.entries(themes)) {
+    const n = normalizeCustomTheme(t);
+    if (n) out[id] = n;
+  }
+  return out;
+}
+
+/** @returns {object[]} valid custom themes in display order */
+export function listCustomThemesOrdered() {
+  const { order } = readState();
+  const valid = listCustomThemes();
+  const seen = new Set();
+  const ordered = [];
+  for (const id of order) {
+    if (valid[id] && !seen.has(id)) {
+      ordered.push(valid[id]);
+      seen.add(id);
+    }
+  }
+  for (const [id, t] of Object.entries(valid)) {
+    if (!seen.has(id)) ordered.push(t);
+  }
+  return ordered;
+}
+
+export function upsertCustomTheme(theme) {
+  const n = normalizeCustomTheme(theme);
+  if (!n) return;
+  const { themes, order } = readState();
+  themesStore.patch({
+    themes: { ...themes, [n.id]: n },
+    order: order.includes(n.id) ? order : [...order, n.id],
+  });
+}
+
+export function removeCustomTheme(id) {
+  const { themes, order } = readState();
+  const { [id]: _drop, ...rest } = themes;
+  themesStore.patch({ themes: rest, order: order.filter((x) => x !== id) });
+}
+```
+
+- [ ] **Step 4: Run, expect PASS.** — `npx vitest run src/theme/customThemesRepo.test.js`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/theme/customThemesRepo.js src/theme/customThemesRepo.test.js
+git commit -m "feat(theme): add customThemesRepo CRUD over themesStore"
+```
+
+---
+
+### Task 4: `themeRegistry` (`getTheme` / `isKnownThemeId`)
+
+**Files:**
+- Create: `src/theme/themeRegistry.js`
+- Test: `src/theme/themeRegistry.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+import { describe, it, expect } from "vitest";
+import { BUILTIN_THEMES } from "./builtinThemes.js";
+import { makeCustomThemeFromBase } from "./customTheme.js";
+import { getTheme, isKnownThemeId } from "./themeRegistry.js";
+
+const custom = makeCustomThemeFromBase(BUILTIN_THEMES["plvs-dark"], "C", () => "custom-1");
+const customs = { "custom-1": custom };
+
+describe("themeRegistry", () => {
+  it("resolves builtins and customs", () => {
+    expect(getTheme("plvs-light", customs)).toBe(BUILTIN_THEMES["plvs-light"]);
+    expect(getTheme("custom-1", customs)).toBe(custom);
+  });
+  it("falls back to plvs-dark for unknown", () => {
+    expect(getTheme("nope", customs)).toBe(BUILTIN_THEMES["plvs-dark"]);
+    expect(getTheme("custom-1", {})).toBe(BUILTIN_THEMES["plvs-dark"]);
+  });
+  it("isKnownThemeId reflects builtins and customs", () => {
+    expect(isKnownThemeId("plvs-dark", customs)).toBe(true);
+    expect(isKnownThemeId("custom-1", customs)).toBe(true);
+    expect(isKnownThemeId("custom-1", {})).toBe(false);
+    expect(isKnownThemeId("nope", customs)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement `src/theme/themeRegistry.js`**
+
+```javascript
+import { BUILTIN_THEMES, DEFAULT_THEME_ID } from "./builtinThemes.js";
+
+/**
+ * @param {unknown} id
+ * @param {Record<string, object>} [customThemes]
+ */
+export function isKnownThemeId(id, customThemes = {}) {
+  if (typeof id !== "string") return false;
+  return id in BUILTIN_THEMES || id in customThemes;
+}
+
+/**
+ * @param {unknown} id
+ * @param {Record<string, object>} [customThemes]
+ * @returns {object} a builtin or custom theme; falls back to plvs-dark
+ */
+export function getTheme(id, customThemes = {}) {
+  if (typeof id === "string") {
+    if (id in BUILTIN_THEMES) return BUILTIN_THEMES[id];
+    if (id in customThemes) return customThemes[id];
+  }
+  return BUILTIN_THEMES[DEFAULT_THEME_ID];
+}
+```
+
+- [ ] **Step 4: Run, expect PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/theme/themeRegistry.js src/theme/themeRegistry.test.js
+git commit -m "feat(theme): add theme registry resolving builtins and customs"
+```
+
+---
+
+### Task 5: `resolveThemeId` accepts custom themes
+
+**Files:**
+- Modify: `src/preferences/themeResolve.js`
+- Test: `src/preferences/themeResolve.test.js`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `src/preferences/themeResolve.test.js`:
+
+```javascript
+import { makeCustomThemeFromBase } from "../theme/customTheme.js";
+import { BUILTIN_THEMES } from "../theme/builtinThemes.js";
+
+describe("resolveThemeId with custom themes", () => {
+  const custom = makeCustomThemeFromBase(BUILTIN_THEMES["plvs-dark"], "C", () => "custom-1");
+  const customs = { "custom-1": custom };
+
+  it("resolves an existing fixed custom id to itself", () => {
+    expect(resolveThemeId({ appearance: "fixed", themeId: "custom-1" }, true, customs)).toBe(
+      "custom-1"
+    );
+  });
+  it("falls back to plvs-dark for a deleted custom id", () => {
+    expect(resolveThemeId({ appearance: "fixed", themeId: "custom-1" }, true, {})).toBe(
+      DEFAULT_THEME_ID
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL** (custom id currently treated as unknown → falls back even when present).
+
+- [ ] **Step 3: Update `resolveThemeId`**
+
+In `src/preferences/themeResolve.js`, import the registry and use it:
+
+```javascript
+import { isKnownThemeId } from "../theme/themeRegistry.js";
+```
+
+Change the signature and the validity check:
+
+```javascript
+export function resolveThemeId(shell, systemPrefersDark, customThemes = {}) {
+  const appearance = shell?.appearance === "fixed" ? "fixed" : "system";
+  if (appearance === "system") {
+    return systemPrefersDark ? DEFAULT_THEME_ID : "plvs-light";
+  }
+  const rawId = shell?.themeId;
+  const id = rawId == null || rawId === "" ? null : String(rawId);
+  if (!isKnownThemeId(id, customThemes)) {
+    if (import.meta.env.DEV && id != null && id !== "") {
+      console.warn(`[PLVS] Unknown themeId "${id}"; falling back to ${DEFAULT_THEME_ID}.`);
+    }
+    return DEFAULT_THEME_ID;
+  }
+  return id;
+}
+```
+
+(Keep the existing `export { DEFAULT_THEME_ID, isThemeId, THEME_IDS }` line and `parsePersistedUiStateJson`/`readPersistedShellThemeFields` unchanged. `readPersistedShellThemeFields` does not resolve, so it needs no custom-themes argument.)
+
+- [ ] **Step 4: Run, expect PASS** — `npx vitest run src/preferences/themeResolve.test.js`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/preferences/themeResolve.js src/preferences/themeResolve.test.js
+git commit -m "feat(theme): resolve fixed custom theme ids via the registry"
+```
+
+---
+
+### Task 6: `applyThemeToDocument` + spectrogram colormap accept custom themes
+
+**Files:**
+- Modify: `src/preferences/applyDocumentTheme.js`
+- Modify: `src/components/panels/SpectrogramPanel.jsx`
+
+- [ ] **Step 1: Update `applyThemeToDocument`**
+
+In `src/preferences/applyDocumentTheme.js`, replace the `getBuiltinTheme` import with the registry and
+accept a `customThemes` argument:
+
+```javascript
+import { getTheme } from "../theme/themeRegistry.js";
+// (remove: import { getBuiltinTheme } from "../theme/builtinThemes.js";)
+
+export function applyThemeToDocument(themeId, customThemes = {}) {
+  if (typeof document === "undefined") return;
+  const theme = getTheme(themeId, customThemes);
+  // ...rest unchanged (dataset.theme = theme.id, color-scheme, buildThemeTokens(theme), geometry)
+}
+```
+
+(Everything after the lookup is unchanged — `buildThemeTokens(theme)` already works for a custom
+theme object.)
+
+- [ ] **Step 2: Point the spectrogram colormap at the registry**
+
+In `src/components/panels/SpectrogramPanel.jsx`, the colormap LUT is built from
+`getBuiltinTheme(resolvedThemeId).colormap`. Switch it to the registry with the custom themes loaded
+from the repo:
+
+```javascript
+import { getTheme } from "../../theme/themeRegistry.js";
+import { listCustomThemes } from "../../theme/customThemesRepo.js";
+// remove the getBuiltinTheme import if it is now unused
+
+const colormapLut = useMemo(
+  () => buildSpectrogramLut(getTheme(resolvedThemeId, listCustomThemes()).colormap),
+  [resolvedThemeId]
+);
+```
+
+(B does not edit colormap, so keying on `resolvedThemeId` is sufficient — the colormap is stable per
+theme.)
+
+- [ ] **Step 3: Run the theme + component tests**
+
+Run: `npx vitest run src/preferences src/theme src/components/panels/SpectrogramPanel.test.jsx`
+Expected: PASS. If `SpectrogramPanel.test.jsx` mocks `getBuiltinTheme`, update the mock to the
+registry's `getTheme` so the "passes the resolved theme colormap" test still drives a dark vs light
+colormap.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/preferences/applyDocumentTheme.js src/components/panels/SpectrogramPanel.jsx src/components/panels/SpectrogramPanel.test.jsx
+git commit -m "feat(theme): apply custom themes through registry in document + spectrogram"
+```
+
+---
+
+### Task 7: Boot + `useSettings` load and pass custom themes
+
+**Files:**
+- Modify: `src/main.jsx`
+- Modify: `src/hooks/useSettings.js`
+
+- [ ] **Step 1: Boot apply (`main.jsx`)**
+
+Load custom themes synchronously at boot and pass them to both resolve and apply:
+
+```javascript
+import { listCustomThemes } from "./theme/customThemesRepo.js";
+
+const systemPrefersDark = readSystemPrefersDark();
+const shell = readPersistedShellThemeFields(UI_PREFERENCES);
+const customThemes = listCustomThemes();
+const resolvedThemeId = resolveThemeId(shell, systemPrefersDark, customThemes);
+applyLayoutToDocument(UI_PREFERENCES);
+applyThemeToDocument(resolvedThemeId, customThemes);
+```
+
+- [ ] **Step 2: Hook wiring (`useSettings.js`)**
+
+Add custom-theme state, feed it into resolve + apply, refresh it on store changes, and make the fixed
+picker value accept custom ids. Edits:
+
+```javascript
+import { listCustomThemes } from "../theme/customThemesRepo.js";
+import { isKnownThemeId } from "../theme/themeRegistry.js";
+import { presetsStore, settingsStore, themesStore } from "../persistence/index.js";
+```
+
+```javascript
+  const [customThemes, setCustomThemes] = useState(() => listCustomThemes());
+
+  const resolvedThemeId = useMemo(
+    () => resolveThemeId({ appearance, themeId }, systemPrefersDark, customThemes),
+    [appearance, themeId, systemPrefersDark, customThemes]
+  );
+```
+
+Update `fixedThemeSelectValue` to accept custom ids:
+
+```javascript
+  const fixedThemeSelectValue = useMemo(() => {
+    if (appearance !== "fixed") return "";
+    return isKnownThemeId(themeId, customThemes) ? themeId : resolvedThemeId;
+  }, [appearance, themeId, resolvedThemeId, customThemes]);
+```
+
+Update the apply effect to pass customThemes:
+
+```javascript
+  useEffect(() => {
+    applyLayoutToDocument(UI_PREFERENCES);
+    applyThemeToDocument(resolvedThemeId, customThemes);
+  }, [resolvedThemeId, customThemes]);
+```
+
+Add a subscription that refreshes custom themes when the store changes:
+
+```javascript
+  useEffect(() => themesStore.subscribe(() => setCustomThemes(listCustomThemes())), []);
+```
+
+(`setFixedThemeIdFromPicker` still guards with `isThemeId`; leave it — Plan 2 will route custom
+selection through a new action. This task only makes the engine custom-aware; no new UI yet.)
+
+- [ ] **Step 3: Verify**
+
+Run: `npx vitest run src/hooks src/preferences src/theme`
+Expected: PASS. (If `useSettings` has a test that constructs the hook, ensure it still mounts; the new
+`themesStore.subscribe` mirrors the existing `settingsStore.subscribe` pattern.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main.jsx src/hooks/useSettings.js
+git commit -m "feat(theme): load and thread custom themes through boot and useSettings"
+```
+
+---
+
+### Task 8: Full verification
+
+- [ ] **Step 1: First-paint unchanged**
+
+Run: `npm run theme:generate` then `git status --short`
+Expected: no change to `src/generated/theme-fallbacks.css` (first paint is still `plvs-dark`).
+
+- [ ] **Step 2: Full project check**
+
+Run: `npm run check`
+Expected: PASS.
+
+- [ ] **Step 3: Headless smoke (seed a custom theme via the store)**
+
+In the app's dev console (or a throwaway test), seed and select a custom theme to confirm end-to-end
+resolution/apply, e.g.:
+
+```javascript
+import { upsertCustomTheme } from "./src/theme/customThemesRepo.js";
+import { makeCustomThemeFromBase } from "./src/theme/customTheme.js";
+import { BUILTIN_THEMES } from "./src/theme/builtinThemes.js";
+const t = makeCustomThemeFromBase(BUILTIN_THEMES["plvs-dark"], "Smoke", () => "custom-smoke");
+upsertCustomTheme({ ...t, seeds: { ...t.seeds, accent: "#22d3ee" } });
+// then set settings appearance=fixed, themeId="custom-smoke" and reload
+```
+Expected: the app renders with the cyan accent. (This is a manual confirmation that Plan 2's UI will
+drive; no commit.)
+
+- [ ] **Step 4: Commit any formatting auto-fixes**
+
+```bash
+git add -A && git commit -m "chore(theme): formatting after custom-theme foundation" || echo "nothing to commit"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §4 `CustomTheme` model (Task 2); §5.1 `themesStore` + export/reset (Task 1) and
+  repo (Task 3); §5.2 registry `getTheme`/`isKnownThemeId` (Task 4), `resolveThemeId(customThemes)`
+  (Task 5), `applyThemeToDocument(customThemes)` + spectrogram colormap (Task 6), boot + `useSettings`
+  threading (Task 7). Deleted-id fallback verified in Task 5.
+- **Out of scope (Plan 2):** floating editor, color control, draft semantics, Settings create/edit/
+  delete UI, routing custom selection through the picker. Task 7 deliberately leaves
+  `setFixedThemeIdFromPicker` guarded by `isThemeId`.
+- **Placeholder scan:** none — full code in every code step.
+- **Type consistency:** `customThemes` is a `Record<id, CustomTheme>` map everywhere
+  (`listCustomThemes` → registry/resolve/apply). `getTheme`/`isKnownThemeId` signatures match their
+  use in Tasks 5–7. `makeCustomThemeFromBase(base, name, makeId)` is used consistently in tests.

--- a/docs/working/superpowers/plans/2026-06-20-custom-themes-plan-2-editor.md
+++ b/docs/working/superpowers/plans/2026-06-20-custom-themes-plan-2-editor.md
@@ -1,0 +1,857 @@
+# Custom Themes — Plan 2: Floating Editor, Color Control, Draft Semantics, Settings UI
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the user duplicate the active theme into a named custom theme and edit its seed + shell colors in a floating, draggable panel with a live full-app preview (draft/save/cancel), and select/delete custom themes from Settings.
+
+**Architecture:** A `useThemeEditor` hook owns the draft state machine and live-applies the draft by overlaying it into the `customThemes` map passed to `applyThemeToDocument`. A `ColorControl` (swatch + popover with native picker + hex + alpha) edits any field; `colorIO` converts between CSS color strings (hex/rgba/oklch) and `{hex, alpha}`. A `ThemeEditor` floating panel renders the fields and Save/Cancel/Delete; `dragClamp` keeps it in-window. Settings gains custom entries + New/Edit/Delete and hides while editing.
+
+**Tech Stack:** JavaScript (ESM), React 19, Vitest. Builds on Plan 1 (model/repo/registry/engine).
+
+**Spec:** `docs/working/superpowers/specs/2026-06-20-custom-themes-design.md` (§6 editor UX, §3 decisions).
+
+**Roadmap:** Plan 2 of 2. Plan 1 (foundation) is on this branch. After Plan 2, custom themes are fully user-creatable/editable.
+
+---
+
+### Task 1: `colorIO` — CSS color string ↔ `{hex, alpha}`
+
+**Files:**
+- Create: `src/theme/colorIO.js`
+- Test: `src/theme/colorIO.test.js`
+
+The color control speaks hex + alpha (0–1); theme values may be hex, `rgba(...)`, or `oklch(...)`.
+`toEditable` parses any to `{hex, alpha}` (reusing the existing oklch string parser); `fromEditable`
+emits hex when alpha≈1 else `rgba(...)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+import { describe, it, expect } from "vitest";
+import { toEditable, fromEditable } from "./colorIO.js";
+
+describe("colorIO", () => {
+  it("parses hex", () => {
+    expect(toEditable("#fb923c")).toEqual({ hex: "#fb923c", alpha: 1 });
+  });
+  it("parses rgba", () => {
+    expect(toEditable("rgba(255,255,255,0.04)")).toEqual({ hex: "#ffffff", alpha: 0.04 });
+  });
+  it("parses oklch (incl alpha)", () => {
+    const e = toEditable("oklch(1 0 0 / 9%)");
+    expect(e.hex.toLowerCase()).toBe("#ffffff");
+    expect(e.alpha).toBeCloseTo(0.09, 2);
+  });
+  it("round-trips: opaque -> hex, translucent -> rgba", () => {
+    expect(fromEditable("#fb923c", 1)).toBe("#fb923c");
+    expect(fromEditable("#ffffff", 0.04)).toBe("rgba(255, 255, 255, 0.04)");
+  });
+  it("falls back to a safe default for unparseable input", () => {
+    expect(toEditable("nonsense").hex).toMatch(/^#[0-9a-f]{6}$/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement `src/theme/colorIO.js`**
+
+```javascript
+import { oklchToHex } from "./shadcnSemanticPreset.js"; // string oklch(...) -> hex/rgba
+
+function clamp01(n) {
+  return Math.max(0, Math.min(1, n));
+}
+
+/** @param {string} value @returns {{hex:string, alpha:number}} */
+export function toEditable(value) {
+  const v = typeof value === "string" ? value.trim() : "";
+  // hex #rrggbb
+  let m = /^#([0-9a-f]{6})$/i.exec(v);
+  if (m) return { hex: `#${m[1].toLowerCase()}`, alpha: 1 };
+  // rgb/rgba
+  m = /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+)\s*)?\)$/i.exec(v);
+  if (m) {
+    const hx = (n) => Number(n).toString(16).padStart(2, "0");
+    return {
+      hex: `#${hx(m[1])}${hx(m[2])}${hx(m[3])}`,
+      alpha: m[4] == null ? 1 : clamp01(parseFloat(m[4])),
+    };
+  }
+  // oklch(...) — reuse the existing string parser, which returns hex or rgba(...)
+  if (v.startsWith("oklch(")) {
+    const out = oklchToHex(v);
+    if (out.startsWith("#")) return { hex: out, alpha: 1 };
+    return toEditable(out); // oklchToHex returned rgba(...) for the alpha case
+  }
+  return { hex: "#808080", alpha: 1 };
+}
+
+/** @param {string} hex @param {number} alpha @returns {string} */
+export function fromEditable(hex, alpha) {
+  if (alpha >= 0.999) return hex;
+  const n = parseInt(hex.slice(1), 16);
+  const a = Math.round(clamp01(alpha) * 1000) / 1000;
+  return `rgba(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255}, ${a})`;
+}
+```
+
+- [ ] **Step 4: Run, expect PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/theme/colorIO.js src/theme/colorIO.test.js
+git commit -m "feat(theme): add colorIO between CSS color strings and {hex, alpha}"
+```
+
+---
+
+### Task 2: `dragClamp` — keep a panel within the window
+
+**Files:**
+- Create: `src/lib/dragClamp.js`
+- Test: `src/lib/dragClamp.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+import { describe, it, expect } from "vitest";
+import { clampPanelPos } from "./dragClamp.js";
+
+describe("clampPanelPos", () => {
+  const win = { w: 1000, h: 800 };
+  const panel = { w: 320, h: 400 };
+  it("keeps a fully-inside position unchanged", () => {
+    expect(clampPanelPos({ x: 100, y: 100 }, panel, win)).toEqual({ x: 100, y: 100 });
+  });
+  it("clamps past the right/bottom edges", () => {
+    expect(clampPanelPos({ x: 900, y: 700 }, panel, win)).toEqual({ x: 680, y: 400 });
+  });
+  it("clamps negative to zero", () => {
+    expect(clampPanelPos({ x: -50, y: -10 }, panel, win)).toEqual({ x: 0, y: 0 });
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement `src/lib/dragClamp.js`**
+
+```javascript
+/**
+ * @param {{x:number,y:number}} pos
+ * @param {{w:number,h:number}} panel
+ * @param {{w:number,h:number}} win
+ * @returns {{x:number,y:number}}
+ */
+export function clampPanelPos(pos, panel, win) {
+  return {
+    x: Math.max(0, Math.min(pos.x, win.w - panel.w)),
+    y: Math.max(0, Math.min(pos.y, win.h - panel.h)),
+  };
+}
+```
+
+- [ ] **Step 4: Run, expect PASS.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/dragClamp.js src/lib/dragClamp.test.js
+git commit -m "feat(ui): add clampPanelPos for in-window floating panels"
+```
+
+---
+
+### Task 3: `useThemeEditor` — draft state machine
+
+**Files:**
+- Create: `src/hooks/useThemeEditor.js`
+- Test: `src/hooks/useThemeEditor.test.js`
+
+The hook applies the draft live by overlaying it into `customThemes` and calling the injected `apply`
+(default `applyThemeToDocument`). It is given the current selection setters so create/cancel can move
+selection. `apply` is injectable for headless testing.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { themesStore } from "../persistence/index.js";
+import { BUILTIN_THEMES } from "../theme/builtinThemes.js";
+import { listCustomThemes } from "../theme/customThemesRepo.js";
+import { useThemeEditor } from "./useThemeEditor.js";
+
+beforeEach(() => themesStore.reset());
+
+function setup(apply) {
+  const selection = { appearance: "fixed", themeId: "plvs-dark" };
+  const setThemeId = vi.fn((id) => (selection.themeId = id));
+  const setAppearance = vi.fn((a) => (selection.appearance = a));
+  return renderHook(() =>
+    useThemeEditor({
+      activeTheme: BUILTIN_THEMES["plvs-dark"],
+      customThemes: listCustomThemes(),
+      prevSelection: { appearance: "fixed", themeId: "plvs-dark" },
+      setThemeId,
+      setAppearance,
+      apply,
+      makeId: () => "custom-1",
+    })
+  );
+}
+
+describe("useThemeEditor", () => {
+  it("beginCreate duplicates the active theme, persists, selects, and applies the draft", () => {
+    const apply = vi.fn();
+    const { result } = setup(apply);
+    act(() => result.current.beginCreate("Sunset"));
+    expect(result.current.isEditing).toBe(true);
+    expect(result.current.draft.name).toBe("Sunset");
+    expect(listCustomThemes()["custom-1"]).toBeTruthy();
+    // applied with the draft overlaid into the map
+    const [id, map] = apply.mock.calls.at(-1);
+    expect(id).toBe("custom-1");
+    expect(map["custom-1"].name).toBe("Sunset");
+  });
+
+  it("updateSeed/updateShell mutate the draft and re-apply", () => {
+    const apply = vi.fn();
+    const { result } = setup(apply);
+    act(() => result.current.beginCreate("S"));
+    act(() => result.current.updateSeed("accent", "#22d3ee"));
+    expect(result.current.draft.seeds.accent).toBe("#22d3ee");
+    act(() => result.current.updateShell("background", "#101010"));
+    expect(result.current.draft.semantic.background).toBe("#101010");
+    expect(apply.mock.calls.at(-1)[1]["custom-1"].semantic.background).toBe("#101010");
+  });
+
+  it("save persists the final draft and ends editing", () => {
+    const apply = vi.fn();
+    const { result } = setup(apply);
+    act(() => result.current.beginCreate("S"));
+    act(() => result.current.updateSeed("accent", "#22d3ee"));
+    act(() => result.current.save());
+    expect(result.current.isEditing).toBe(false);
+    expect(listCustomThemes()["custom-1"].seeds.accent).toBe("#22d3ee");
+  });
+
+  it("cancel of a newly-created theme removes it and restores previous selection", () => {
+    const apply = vi.fn();
+    const { result } = setup(apply);
+    act(() => result.current.beginCreate("S"));
+    act(() => result.current.cancel());
+    expect(result.current.isEditing).toBe(false);
+    expect(listCustomThemes()["custom-1"]).toBeUndefined();
+    // re-applied the previous theme without the draft overlay
+    expect(apply.mock.calls.at(-1)[0]).toBe("plvs-dark");
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement `src/hooks/useThemeEditor.js`**
+
+```javascript
+import { useCallback, useRef, useState } from "react";
+import { applyThemeToDocument } from "../uiPreferences";
+import { makeCustomThemeFromBase } from "../theme/customTheme.js";
+import { listCustomThemes, upsertCustomTheme, removeCustomTheme } from "../theme/customThemesRepo.js";
+
+/**
+ * @param {{
+ *   activeTheme: object,
+ *   customThemes: Record<string, object>,
+ *   prevSelection: { appearance: string, themeId: string|null },
+ *   setThemeId: (id: string) => void,
+ *   setAppearance: (a: string) => void,
+ *   apply?: (id: string, customThemes: Record<string, object>) => void,
+ *   makeId?: () => string,
+ * }} opts
+ */
+export function useThemeEditor(opts) {
+  const apply = opts.apply ?? applyThemeToDocument;
+  const [draft, setDraft] = useState(/** @type {object|null} */ (null));
+  const wasNewRef = useRef(false);
+  const prevRef = useRef(opts.prevSelection);
+
+  const applyDraft = useCallback(
+    (next) => apply(next.id, { ...listCustomThemes(), [next.id]: next }),
+    [apply]
+  );
+
+  const beginEdit = useCallback(
+    (theme) => {
+      wasNewRef.current = false;
+      prevRef.current = { appearance: "fixed", themeId: theme.id };
+      const d = structuredClone(theme);
+      setDraft(d);
+      applyDraft(d);
+    },
+    [applyDraft]
+  );
+
+  const beginCreate = useCallback(
+    (name) => {
+      wasNewRef.current = true;
+      prevRef.current = opts.prevSelection;
+      const d = makeCustomThemeFromBase(opts.activeTheme, name, opts.makeId);
+      upsertCustomTheme(d);
+      opts.setAppearance("fixed");
+      opts.setThemeId(d.id);
+      setDraft(d);
+      applyDraft(d);
+    },
+    [opts, applyDraft]
+  );
+
+  const setName = useCallback((name) => {
+    setDraft((d) => (d ? { ...d, name: String(name) } : d));
+  }, []);
+
+  const updateSeed = useCallback(
+    (key, value) => {
+      setDraft((d) => {
+        if (!d) return d;
+        const next =
+          key === "good" || key === "warn" || key === "bad"
+            ? { ...d, seeds: { ...d.seeds, signal: { ...d.seeds.signal, [key]: value } } }
+            : { ...d, seeds: { ...d.seeds, [key]: value } };
+        applyDraft(next);
+        return next;
+      });
+    },
+    [applyDraft]
+  );
+
+  const updateShell = useCallback(
+    (key, value) => {
+      setDraft((d) => {
+        if (!d) return d;
+        const next = { ...d, semantic: { ...d.semantic, [key]: value } };
+        applyDraft(next);
+        return next;
+      });
+    },
+    [applyDraft]
+  );
+
+  const save = useCallback(() => {
+    setDraft((d) => {
+      if (d) upsertCustomTheme(d);
+      return null;
+    });
+  }, []);
+
+  const cancel = useCallback(() => {
+    setDraft((d) => {
+      if (d && wasNewRef.current) removeCustomTheme(d.id);
+      const prev = prevRef.current;
+      opts.setAppearance(prev.appearance);
+      opts.setThemeId(prev.themeId);
+      apply(
+        prev.appearance === "fixed" ? prev.themeId : "plvs-dark",
+        listCustomThemes()
+      );
+      return null;
+    });
+  }, [opts, apply]);
+
+  return {
+    isEditing: draft != null,
+    draft,
+    beginCreate,
+    beginEdit,
+    setName,
+    updateSeed,
+    updateShell,
+    save,
+    cancel,
+  };
+}
+```
+
+- [ ] **Step 4: Run, expect PASS.** (Uses `@testing-library/react`'s `renderHook` — already a dev dep
+  since the project tests hooks. If not present, install it as a dev dependency.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useThemeEditor.js src/hooks/useThemeEditor.test.js
+git commit -m "feat(theme): add useThemeEditor draft state machine"
+```
+
+---
+
+### Task 4: `ColorControl` component
+
+**Files:**
+- Create: `src/components/ColorControl.jsx`
+- Test: `src/components/ColorControl.test.jsx`
+
+Swatch button opening a popover with a native color input, a hex text input, and an alpha range.
+Emits a CSS color string via `onChange`.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ColorControl } from "./ColorControl.jsx";
+
+describe("ColorControl", () => {
+  it("shows the current color and emits hex at full alpha", () => {
+    const onChange = vi.fn();
+    render(<ColorControl label="Accent" value="#fb923c" onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /accent/i }));
+    fireEvent.input(screen.getByLabelText(/hex/i), { target: { value: "#22d3ee" } });
+    expect(onChange).toHaveBeenLastCalledWith("#22d3ee");
+  });
+  it("emits rgba when alpha < 1", () => {
+    const onChange = vi.fn();
+    render(<ColorControl label="Border" value="#ffffff" onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /border/i }));
+    fireEvent.input(screen.getByLabelText(/alpha/i), { target: { value: "0.5" } });
+    expect(onChange).toHaveBeenLastCalledWith("rgba(255, 255, 255, 0.5)");
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect FAIL.**
+
+- [ ] **Step 3: Implement `src/components/ColorControl.jsx`**
+
+```jsx
+import { useState } from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Label } from "@/components/ui/label";
+import { toEditable, fromEditable } from "../theme/colorIO.js";
+
+/**
+ * @param {{ label: string, value: string, onChange: (css: string) => void }} props
+ */
+export function ColorControl({ label, value, onChange }) {
+  const edit = toEditable(value);
+  const [hex, setHex] = useState(edit.hex);
+  const [alpha, setAlpha] = useState(edit.alpha);
+
+  function emit(nextHex, nextAlpha) {
+    setHex(nextHex);
+    setAlpha(nextAlpha);
+    onChange(fromEditable(nextHex, nextAlpha));
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={label}
+          className="flex items-center gap-2 text-left"
+        >
+          <span
+            className="h-5 w-5 rounded border border-border"
+            style={{ backgroundColor: value }}
+          />
+          <span className="text-[length:var(--ui-fs-metric-meta)]">{label}</span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="flex w-56 flex-col gap-2">
+        <input
+          type="color"
+          aria-label={`${label} picker`}
+          value={hex}
+          onInput={(e) => emit(e.target.value, alpha)}
+        />
+        <div className="flex items-center gap-2">
+          <Label htmlFor={`${label}-hex`}>Hex</Label>
+          <input
+            id={`${label}-hex`}
+            aria-label={`${label} hex`}
+            value={hex}
+            onInput={(e) => /^#[0-9a-f]{6}$/i.test(e.target.value) && emit(e.target.value, alpha)}
+            className="flex-1 rounded border border-input bg-transparent px-2 py-1"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <Label htmlFor={`${label}-alpha`}>Alpha</Label>
+          <input
+            id={`${label}-alpha`}
+            aria-label={`${label} alpha`}
+            type="range"
+            min="0"
+            max="1"
+            step="0.01"
+            value={alpha}
+            onInput={(e) => emit(hex, parseFloat(e.target.value))}
+            className="flex-1"
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+```
+
+- [ ] **Step 4: Run, expect PASS.** (If the popover content does not mount in jsdom until opened,
+  the test already clicks the trigger first; if Radix popover needs it, wrap with the existing test
+  setup other component tests use.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/ColorControl.jsx src/components/ColorControl.test.jsx
+git commit -m "feat(ui): add ColorControl swatch + hex + alpha picker"
+```
+
+---
+
+### Task 5: `ThemeEditor` floating draggable panel
+
+**Files:**
+- Create: `src/components/ThemeEditor.jsx`
+
+This is presentational + drag. It renders nothing when not editing. Props come from `useThemeEditor`
+plus position persistence. Match existing component styling conventions (Card-like surface, the
+`--ui-*` tokens) the way the rest of `src/components` does.
+
+- [ ] **Step 1: Implement `src/components/ThemeEditor.jsx`**
+
+```jsx
+import { useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { ColorControl } from "./ColorControl.jsx";
+import { clampPanelPos } from "../lib/dragClamp.js";
+
+const SHELL_GROUPS = [
+  { title: "Surface", keys: ["background", "card", "popover", "secondary", "muted", "accent"] },
+  { title: "Text", keys: ["foreground", "cardForeground", "popoverForeground", "mutedForeground", "secondaryForeground", "accentForeground"] },
+  { title: "Brand", keys: ["primary", "primaryForeground", "ring", "destructive", "destructiveForeground"] },
+  { title: "Lines", keys: ["border", "input"] },
+];
+
+/**
+ * @param {{
+ *   draft: object,
+ *   onName: (s: string) => void,
+ *   onSeed: (key: string, css: string) => void,
+ *   onShell: (key: string, css: string) => void,
+ *   onSave: () => void,
+ *   onCancel: () => void,
+ *   onDelete?: () => void,
+ *   pos: {x:number,y:number},
+ *   onMove: (p: {x:number,y:number}) => void,
+ * }} props
+ */
+export function ThemeEditor({ draft, onName, onSeed, onShell, onSave, onCancel, onDelete, pos, onMove }) {
+  const ref = useRef(null);
+  const dragRef = useRef(null);
+
+  function onPointerDown(e) {
+    const rect = ref.current.getBoundingClientRect();
+    dragRef.current = { dx: e.clientX - rect.left, dy: e.clientY - rect.top, w: rect.width, h: rect.height };
+    e.currentTarget.setPointerCapture(e.pointerId);
+  }
+  function onPointerMove(e) {
+    const d = dragRef.current;
+    if (!d) return;
+    onMove(
+      clampPanelPos(
+        { x: e.clientX - d.dx, y: e.clientY - d.dy },
+        { w: d.w, h: d.h },
+        { w: window.innerWidth, h: window.innerHeight }
+      )
+    );
+  }
+  function onPointerUp() {
+    dragRef.current = null;
+  }
+
+  return (
+    <div
+      ref={ref}
+      role="dialog"
+      aria-label="Theme editor"
+      className="fixed z-50 flex max-h-[80vh] w-80 flex-col gap-2 overflow-hidden rounded-[var(--ui-radius-modal)] border border-border bg-card text-card-foreground shadow-lg"
+      style={{ left: pos.x, top: pos.y }}
+    >
+      <div
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        className="flex cursor-move items-center justify-between border-b border-border px-3 py-2"
+      >
+        <input
+          aria-label="Theme name"
+          value={draft.name}
+          onInput={(e) => onName(e.target.value)}
+          className="bg-transparent text-[length:var(--ui-fs-panel-title)] font-semibold"
+        />
+        <span className="text-[length:var(--ui-fs-status)] text-muted-foreground">{draft.colorScheme}</span>
+      </div>
+
+      <div className="flex flex-col gap-3 overflow-y-auto px-3 py-2">
+        <section className="flex flex-col gap-1.5">
+          <Label>Seeds</Label>
+          <ColorControl label="Accent" value={draft.seeds.accent} onChange={(c) => onSeed("accent", c)} />
+          <ColorControl label="Accent 2" value={draft.seeds.accentSecondary} onChange={(c) => onSeed("accentSecondary", c)} />
+          <ColorControl label="Signal Good" value={draft.seeds.signal.good} onChange={(c) => onSeed("good", c)} />
+          <ColorControl label="Signal Warn" value={draft.seeds.signal.warn} onChange={(c) => onSeed("warn", c)} />
+          <ColorControl label="Signal Bad" value={draft.seeds.signal.bad} onChange={(c) => onSeed("bad", c)} />
+        </section>
+        {SHELL_GROUPS.map((g) => (
+          <section key={g.title} className="flex flex-col gap-1.5">
+            <Label>{g.title}</Label>
+            {g.keys.map((k) => (
+              <ColorControl key={k} label={k} value={draft.semantic[k]} onChange={(c) => onShell(k, c)} />
+            ))}
+          </section>
+        ))}
+      </div>
+
+      <div className="flex items-center justify-between gap-2 border-t border-border px-3 py-2">
+        {onDelete ? (
+          <Button variant="ghost" onClick={onDelete} className="text-destructive">Delete</Button>
+        ) : <span />}
+        <div className="flex gap-2">
+          <Button variant="ghost" onClick={onCancel}>Cancel</Button>
+          <Button onClick={onSave}>Save</Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Lint check**
+
+Run: `npx eslint src/components/ThemeEditor.jsx`
+Expected: no errors. (No test for the drag interaction itself — `clampPanelPos` is unit-tested in
+Task 2.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/ThemeEditor.jsx
+git commit -m "feat(ui): add floating draggable ThemeEditor panel"
+```
+
+---
+
+### Task 6: Wire editor + actions into `useSettings`
+
+**Files:**
+- Modify: `src/hooks/useSettings.js`
+
+Expose the editor, the ordered custom options, selection routing, and create/delete actions. Persist
+the editor position.
+
+- [ ] **Step 1: Add wiring**
+
+Add imports:
+
+```javascript
+import { listCustomThemesOrdered, removeCustomTheme } from "../theme/customThemesRepo.js";
+import { getTheme } from "../theme/themeRegistry.js";
+import { useThemeEditor } from "./useThemeEditor.js";
+import { isCustomThemeId } from "../theme/customTheme.js";
+```
+
+Add state + editor + actions inside `useSettings` (after `customThemes` from Plan 1):
+
+```javascript
+  const [editorPos, setEditorPos] = useState(
+    () => settingsStore.read().themeEditorPos ?? { x: 80, y: 80 }
+  );
+  function moveEditor(pos) {
+    setEditorPos(pos);
+    settingsStore.patch({ themeEditorPos: pos });
+  }
+
+  const editor = useThemeEditor({
+    activeTheme: getTheme(resolvedThemeId, customThemes),
+    customThemes,
+    prevSelection: { appearance, themeId },
+    setThemeId,
+    setAppearance,
+  });
+
+  const customThemeOptions = useMemo(
+    () => listCustomThemesOrdered().map((t) => ({ id: t.id, label: t.name })),
+    [customThemes]
+  );
+
+  function selectThemeId(id) {
+    setAppearance("fixed");
+    setThemeId(id);
+  }
+  function createCustomTheme() {
+    setSettingsOpen(false);
+    editor.beginCreate(`${getTheme(resolvedThemeId, customThemes).label ?? "Theme"} copy`);
+  }
+  function editActiveCustomTheme() {
+    if (!isCustomThemeId(resolvedThemeId)) return;
+    setSettingsOpen(false);
+    editor.beginEdit(getTheme(resolvedThemeId, customThemes));
+  }
+  function deleteCustomTheme(id) {
+    removeCustomTheme(id);
+    setCustomThemes(listCustomThemes());
+    if (themeId === id) selectThemeId("plvs-dark");
+  }
+```
+
+Replace `setFixedThemeIdFromPicker` body so it accepts custom ids:
+
+```javascript
+  function setFixedThemeIdFromPicker(id) {
+    if (!isKnownThemeId(id, customThemes)) return;
+    setAppearance("fixed");
+    setThemeId(id);
+  }
+```
+
+Add to the returned object: `editor`, `editorPos`, `moveEditor`, `customThemeOptions`,
+`createCustomTheme`, `editActiveCustomTheme`, `deleteCustomTheme`, and a convenience
+`activeIsCustom: isCustomThemeId(resolvedThemeId)`.
+
+- [ ] **Step 2: Verify**
+
+Run: `npx vitest run src/hooks`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useSettings.js
+git commit -m "feat(theme): expose custom-theme editor and CRUD actions from useSettings"
+```
+
+---
+
+### Task 7: Settings picker entries + buttons; mount the editor
+
+**Files:**
+- Modify: `src/components/SettingsPanel.jsx`
+- Modify: `src/App.jsx`
+
+- [ ] **Step 1: Settings — list customs + New/Edit/Delete**
+
+In `src/components/SettingsPanel.jsx`, the `appearance === "fixed"` block's `<Select>` currently maps
+only `themeSelectOptions` (builtins). Add a custom group and action buttons. Use the new props from
+`useSettings` (thread them through the existing `SettingsPanel` prop list): `customThemeOptions`,
+`createCustomTheme`, `editActiveCustomTheme`, `deleteCustomTheme`, `activeIsCustom`,
+`fixedThemeSelectValue`, `setFixedThemeIdFromPicker`.
+
+Inside `<SelectContent>` after the builtin items, append:
+
+```jsx
+{customThemeOptions.map((opt) => (
+  <SelectItem key={opt.id} value={opt.id}>{opt.label}</SelectItem>
+))}
+```
+
+After the `<Select>`, add an action row:
+
+```jsx
+<div className="flex items-center gap-2">
+  <Button size="sm" variant="ghost" onClick={createCustomTheme}>Duplicate</Button>
+  {activeIsCustom ? (
+    <>
+      <Button size="sm" variant="ghost" onClick={editActiveCustomTheme}>Edit</Button>
+      <Button size="sm" variant="ghost" className="text-destructive"
+        onClick={() => deleteCustomTheme(fixedThemeSelectValue)}>Delete</Button>
+    </>
+  ) : null}
+</div>
+```
+
+- [ ] **Step 2: App — mount the floating editor**
+
+In `src/App.jsx`, destructure the new fields from `useSettings` (where `SettingsPanel` props are
+gathered ~line 145–169), pass the Settings ones into `<SettingsPanel ... />`, and mount the editor
+next to it (~line 1289):
+
+```jsx
+{settings.editor.isEditing ? (
+  <ThemeEditor
+    draft={settings.editor.draft}
+    onName={settings.editor.setName}
+    onSeed={settings.editor.updateSeed}
+    onShell={settings.editor.updateShell}
+    onSave={settings.editor.save}
+    onCancel={settings.editor.cancel}
+    onDelete={settings.activeIsCustom ? () => settings.editor.cancel() /* see note */ : undefined}
+    pos={settings.editorPos}
+    onMove={settings.moveEditor}
+  />
+) : null}
+```
+
+Add `import { ThemeEditor } from "./components/ThemeEditor";` at the top. NOTE on Delete-in-editor:
+deleting while editing should remove the theme and close — implement `onDelete` as a small handler in
+`App`/`useSettings` that calls `deleteCustomTheme(draft.id)` then `editor.cancel()`-style teardown
+without re-saving; if that proves fiddly, omit the in-editor Delete (Settings already has Delete) and
+pass `onDelete={undefined}`.
+
+(Use whatever variable name `useSettings()` is assigned to in `App.jsx` — shown here as `settings`.)
+
+- [ ] **Step 3: Lint + targeted tests**
+
+Run: `npx eslint src/components/SettingsPanel.jsx src/App.jsx` and `npx vitest run src/components`
+Expected: no eslint errors; component tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/SettingsPanel.jsx src/App.jsx
+git commit -m "feat(theme): add custom themes to Settings picker and mount the editor"
+```
+
+---
+
+### Task 8: Full verification + manual smoke
+
+- [ ] **Step 1: Full check**
+
+Run: `npm run check`
+Expected: PASS.
+
+- [ ] **Step 2: Manual smoke**
+
+Launch the app → Settings → Appearance: Fixed → **Duplicate**. The Settings sheet hides and the
+floating editor appears. Drag it by its title bar to a corner (it stays in-window). Edit **Accent** —
+the whole UI (buttons, loudness/spectrum traces) recolors live. Edit a **shell** color (e.g.
+background). Rename to "Smoke". **Save** → editor closes, app shows the custom theme; reopen Settings
+and confirm "Smoke" is selected in the picker. **Duplicate** again, change a color, **Cancel** → the
+new theme is discarded and the prior theme returns. Select a custom theme, **Delete** → falls back to
+Dark. Quit and relaunch with a custom theme active → it reapplies (with a brief default-dark first
+paint, as expected).
+
+- [ ] **Step 3: Commit any formatting auto-fixes**
+
+```bash
+git add -A && git commit -m "chore(theme): formatting after custom theme editor" || echo "nothing to commit"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §6.1 entry points = Duplicate(active)/Edit/Delete (Tasks 6–7); §6.2 floating
+  draggable, clamped, position-persisted panel (Tasks 2, 5, 6); §6.3 alpha-capable color control
+  (Tasks 1, 4); §6.4 draft/save/cancel incl. create-cancel-discards (Task 3); hide-Settings-on-edit
+  (Task 6 `setSettingsOpen(false)`); close→return-to-app (editor unmount, no reopen). Invariant
+  "edit = active theme" enforced (beginEdit/createCustomTheme use `getTheme(resolvedThemeId,…)`).
+- **Out of scope (slice C):** colormap editing, community import, system-mode mapping, colorScheme
+  flip — none added.
+- **Placeholder scan:** the only soft spot is the in-editor Delete handler (Task 7 Step 2), which has
+  an explicit concrete fallback (omit it; Settings provides Delete) — not a blocking placeholder.
+- **Type consistency:** `useThemeEditor` returns `{ isEditing, draft, beginCreate, beginEdit, setName,
+  updateSeed, updateShell, save, cancel }` (Task 3) — consumed verbatim in Tasks 6–7. `ColorControl`
+  `{label,value,onChange}` and `ThemeEditor` props match their call sites. `colorIO` `toEditable`/
+  `fromEditable` and `clampPanelPos` signatures match their importers.

--- a/docs/working/superpowers/specs/2026-06-20-custom-themes-design.md
+++ b/docs/working/superpowers/specs/2026-06-20-custom-themes-design.md
@@ -1,0 +1,177 @@
+# User Custom Themes — Design
+
+Date: 2026-06-20
+Status: Approved design (pending implementation plan)
+
+## 1. Background & Goals
+
+The theme-token refactor (`2026-06-19-theme-token-seed-refactor-design.md`) left PLVS with a clean
+seed/derive model: a theme is `{ id, label, colorScheme, semantic (shell), seeds, colormap }`, and
+`buildThemeTokens(theme)` derives every instrument color. This was deliberately built to support
+**user-designed themes** — the deferred "phase 3".
+
+This spec covers the **first user-theming slice (level "B")**: a user can duplicate a builtin theme
+into a named **custom theme**, edit its **seed colors AND shell colors** in a floating editor with a
+**live, full-app preview**, and select it like any builtin. The editor and data model reuse the
+existing seed/derive pipeline with no special-casing in the render path.
+
+**Out of scope (later slices, "C"):** editing the spectrogram colormap, importing community shadcn
+presets (paste-CSS → shell) and the accent/primary collision rule, user-swappable colormap presets,
+export/share of individual themes, and `system`-mode mapping to custom themes.
+
+## 2. Scope
+
+**In scope**
+- A `CustomTheme` data model (full standalone snapshot, shaped like a builtin theme).
+- A `themesStore` persistence domain for the custom-theme collection.
+- A theme **registry/resolution** layer so a custom id resolves to its theme object; deleted/unknown
+  ids fall back to `plvs-dark`.
+- A floating, draggable **editor panel** (clamped in-window, remembers position) with live preview.
+- Editing of **seeds** (5 colors) and **shell** (19 shadcn semantic values, alpha-capable).
+- Draft / Save / Cancel semantics applied live via `applyThemeToDocument`.
+- Create = **duplicate the currently active theme**; rename, delete, duplicate of custom themes.
+
+**Out of scope** — see §1.
+
+## 3. Decisions (locked during brainstorming)
+
+1. **Data model = full standalone snapshot** (not override-on-base). A custom theme copies the base's
+   shell/seeds/colormap/colorScheme at creation and is thereafter self-contained.
+2. **Custom themes are only selectable under `appearance: "fixed"`.** `system` mode keeps following
+   the OS between the two **builtin** themes; it never maps to a custom theme.
+3. **Live preview = apply the draft to the whole real app** (`applyThemeToDocument(draft)`), not a
+   contained preview component.
+4. **Editor is a floating, draggable panel** (not a Settings sub-view). Opening it **hides** the
+   Settings sheet; it is non-modal with no dimming overlay; clamped to the window; position is
+   remembered.
+5. **Invariant: editing always operates on the currently active theme.** Selecting a custom theme
+   activates it; only the active theme can be edited. This makes the live preview unambiguous.
+6. **Create = duplicate the active theme** (no separate "pick a base" step). `colorScheme` is
+   inherited from the active theme. To start from Light, select Light first, then duplicate.
+7. **Closing the editor returns to the app** (Settings does not auto-reopen).
+8. **`colorScheme` is fixed at creation** (B does not let the user flip dark↔light for a custom theme).
+9. **colormap is copied from the base and not editable in B.**
+
+## 4. Data Model
+
+```
+CustomTheme = {
+  id: "custom-<uuid>",            // distinct from builtin ids
+  name: string,                   // user-facing label, shown in the picker
+  colorScheme: "dark" | "light",  // inherited at creation, fixed in B
+  seeds: {
+    accent: string,
+    accentSecondary: string,
+    signal: { good: string, warn: string, bad: string },
+  },
+  semantic: { /* the 19 shadcn shell keys, same shape as PLVS_SEMANTIC_DARK */ },
+  colormap: SpectrogramColorStops,  // copied from base; not edited in B
+}
+```
+
+This is structurally identical to a `BuiltinTheme` minus `label` (uses `name`) — so it feeds
+`buildThemeTokens`, the shell application, and the spectrogram colormap path with **zero render-path
+special-casing**.
+
+Color **values** may be any CSS color string (hex, `rgba(...)`, or `oklch(...)`). A freshly
+duplicated theme carries the base's `oklch(...)` shell strings; once a field is edited it becomes the
+color control's output (hex or `rgba`). Mixed formats within one theme are fine —
+`applyShadcnSemanticTokensToDocument` + `oklchSafe` accept any CSS color, and `buildThemeTokens`
+operates on the (hex) seeds.
+
+## 5. Persistence & Resolution
+
+### 5.1 Storage
+- New domain store **`themesStore`** (`createDomainStore({ name: "plvs:themes", backend })`), sibling
+  to `settingsStore`/`workspaceStore`/`presetsStore`. Holds `{ themes: { [id]: CustomTheme }, order:
+  string[] }`.
+- `settingsStore` is unchanged in shape: it still persists `appearance` + `themeId`; `themeId` may now
+  be a `custom-…` id.
+- `themesStore` is added to `exportAll()` and `resetAll()` in `src/persistence/index.js`.
+
+### 5.2 Registry / resolution
+The render path must resolve any id (builtin or custom) to a theme object. Introduce a small registry:
+- `getTheme(id, customThemes) -> BuiltinTheme | CustomTheme` — builtin first, then custom; falls back
+  to `BUILTIN_THEMES["plvs-dark"]` for unknown/deleted ids.
+- `isKnownThemeId(id, customThemes) -> boolean` — true if a builtin or an existing custom.
+- `resolveThemeId(shell, systemPrefersDark, customThemes)` — extend the existing resolver: under
+  `fixed`, an existing custom id resolves to itself; an unknown/deleted id falls back to
+  `DEFAULT_THEME_ID` (this is how "deleting the active custom theme returns to Dark" works).
+- `applyThemeToDocument` takes/looks up the resolved theme **object** via `getTheme` instead of
+  `getBuiltinTheme`, then runs the existing `buildThemeTokens` + shell + colormap writes unchanged.
+
+Custom themes are loaded from `themesStore` and provided to these functions (via `useSettings`, which
+already owns `appearance`/`themeId` and the resolved theme). First-paint (`theme:generate`) is
+untouched — it emits `plvs-dark` only; a fixed custom theme is applied by JS after load, exactly like
+a fixed builtin today.
+
+## 6. Editor UX
+
+### 6.1 Entry points (Settings → fixed theme picker)
+- The picker lists builtins (Dark, Light) + custom themes.
+- **Duplicate / New** (one primitive): duplicates the **currently active** theme into a new
+  `CustomTheme` (`name` e.g. `"<base> copy"`), activates the copy, **hides the Settings sheet**, and
+  opens the floating editor.
+- A selected **custom** theme shows **Edit**, **Delete**, **Duplicate**. Builtins show only
+  **Duplicate** (they are not editable).
+- Deleting the active custom theme reverts selection to `plvs-dark`.
+
+### 6.2 Floating editor panel
+- Rendered outside the Settings sheet; **non-modal, no dimming overlay**.
+- **Draggable by its title bar**, position **clamped within the window**; last position persisted in
+  `settingsStore` (e.g. `themeEditorPos: {x,y}`).
+- Contents:
+  - **Name** input; `colorScheme` shown read-only.
+  - **Seeds** group: `accent`, `accentSecondary`, `signal.good/warn/bad` (5 color controls).
+  - **Shell** group: the 19 shadcn semantic values, sub-grouped (surface / text / border / brand…),
+    scrollable.
+  - Actions: **Save**, **Cancel**, and **Delete** (when editing an existing theme).
+- Closing (Save or Cancel) returns to the app; Settings does not auto-reopen.
+
+### 6.3 Color control
+- One reusable control used for every field: a **swatch button** opening a popover with a picker, a
+  hex input, and an **alpha slider** (needed because shell `--border`/`--input` are semi-transparent).
+  No third-party color-picker dependency. Solid fields simply sit at alpha = 100%.
+- The control emits a CSS color string (hex when alpha = 100%, else `rgba(...)`).
+
+### 6.4 Draft / Save / Cancel semantics
+1. Opening the editor snapshots the active theme into an in-memory **draft**.
+2. Each edit updates the draft and immediately calls `applyThemeToDocument(draft)` — the real UI
+   recolors live.
+3. **Save** writes the draft to `themesStore` (overwriting that custom theme) and keeps it active.
+4. **Cancel** discards the draft and re-applies the theme that was active **before** the editor
+   opened. For a just-created (duplicated) theme, Cancel also **discards the new theme** entirely and
+   reverts to the previously active theme.
+
+## 7. Testing
+
+- **`themesStore` CRUD:** create (duplicate), rename, delete, duplicate; persistence round-trip.
+- **Registry/resolution:** `getTheme`/`isKnownThemeId` with a custom present; `resolveThemeId` returns
+  an existing custom id under `fixed`, and falls back to `plvs-dark` for a deleted/unknown id
+  (includes the "delete active custom theme → fallback" case).
+- **Draft semantics (pure logic):** edit mutates draft; Cancel restores the pre-edit theme; create +
+  Cancel discards the new theme. Assert which theme object would be applied in each case (inject the
+  apply function so it is observable without a DOM).
+- **Color control:** emits hex at alpha 100%, `rgba(...)` below 100%; round-trips an `oklch(...)`
+  input value (displays it, leaves it unchanged until edited).
+- **Clamp-in-window:** the panel-position clamp function keeps the panel within bounds (unit test the
+  pure math; the drag interaction itself is not unit-tested).
+- **Pass-through:** `buildThemeTokens(customTheme)` produces the same token set as for a builtin (no
+  special-casing) — a custom theme with the dark seeds yields dark's derived tokens.
+- **Migration:** existing persisted `themeId = <builtin>` still resolves; `themeId = custom-…` resolves
+  when present.
+- `npm run check` must pass.
+
+## 8. Deferred / Future (slice "C")
+
+- Editing the spectrogram colormap; user-swappable colormap presets (viridis/magma/…).
+- Importing community shadcn presets (paste CSS → shell) and the accent/primary collision rule.
+- Export/share of individual custom themes.
+- `system`-mode mapping to custom themes (designate a custom "dark" and "light").
+- Letting a custom theme flip `colorScheme`.
+
+## 9. Open Items Folded Into the Plan
+
+- Exact sub-grouping/labels of the 19 shell fields in the editor.
+- The color-control popover's exact layout (picker + hex + alpha).
+- Whether `themeEditorPos` lives in `settingsStore` or a tiny dedicated key.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -61,10 +61,12 @@ pub fn run() {
       let settings = store.get("plvs:settings").unwrap_or(serde_json::json!({}));
       let workspace = store.get("plvs:workspace").unwrap_or(serde_json::json!({}));
       let presets = store.get("plvs:presets").unwrap_or(serde_json::json!({}));
+      let themes = store.get("plvs:themes").unwrap_or(serde_json::json!({}));
       let initial = serde_json::json!({
         "plvs:settings": settings,
         "plvs:workspace": workspace,
         "plvs:presets": presets,
+        "plvs:themes": themes,
       });
       let init_script = format!("window.__PLVS_INITIAL_STATE__ = {};", initial);
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,6 +36,7 @@ import {
 import { getPeakMeterChannelLabels } from "./math/peakMeterChannelLabels.js";
 import { getBuiltinTheme } from "./theme/builtinThemes.js";
 import { SettingsPanel } from "./components/SettingsPanel";
+import { ThemeEditor } from "./components/ThemeEditor";
 import { StatusPill } from "./components/StatusPill.jsx";
 import { TransportButton } from "./components/TransportButton.jsx";
 import { IconButton } from "./components/IconButton.jsx";
@@ -166,6 +167,14 @@ function AppContent() {
     setFocusView,
     setAutoHideControls,
     setCompactPanels,
+    editor,
+    editorPos,
+    moveEditor,
+    customThemeOptions,
+    createCustomTheme,
+    editActiveCustomTheme,
+    deleteCustomTheme,
+    activeIsCustom,
   } = useSettings({ onClearRef });
   const { pinned, setPinned, togglePin } = useAlwaysOnTop();
   const presets = usePresets({
@@ -1320,7 +1329,26 @@ function AppContent() {
           setClearCapturing={setClearCapturing}
           clearReady={clearReady}
           registrationError={registrationError}
+          customThemeOptions={customThemeOptions}
+          createCustomTheme={createCustomTheme}
+          editActiveCustomTheme={editActiveCustomTheme}
+          deleteCustomTheme={deleteCustomTheme}
+          activeIsCustom={activeIsCustom}
         />
+
+        {editor.isEditing ? (
+          <ThemeEditor
+            draft={editor.draft}
+            onName={editor.setName}
+            onSeed={editor.updateSeed}
+            onShell={editor.updateShell}
+            onSave={editor.save}
+            onCancel={editor.cancel}
+            onDelete={undefined}
+            pos={editorPos}
+            onMove={moveEditor}
+          />
+        ) : null}
 
         <CloseConfirmDialog
           open={closeDialogOpen}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1345,6 +1345,7 @@ function AppContent() {
             onSave={editor.save}
             onCancel={editor.cancel}
             onDelete={undefined}
+            dirty={editor.dirty}
             pos={editorPos}
             onMove={moveEditor}
           />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1334,6 +1334,7 @@ function AppContent() {
           editActiveCustomTheme={editActiveCustomTheme}
           deleteCustomTheme={deleteCustomTheme}
           activeIsCustom={activeIsCustom}
+          themeControlsDisabled={editor.isEditing}
         />
 
         {editor.isEditing ? (

--- a/src/components/ColorControl.jsx
+++ b/src/components/ColorControl.jsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Label } from "@/components/ui/label";
+import { toEditable, fromEditable } from "../theme/colorIO.js";
+
+/**
+ * @param {{ label: string, value: string, onChange: (css: string) => void }} props
+ */
+export function ColorControl({ label, value, onChange }) {
+  const edit = toEditable(value);
+  const [hex, setHex] = useState(edit.hex);
+  const [alpha, setAlpha] = useState(edit.alpha);
+
+  function emit(nextHex, nextAlpha) {
+    setHex(nextHex);
+    setAlpha(nextAlpha);
+    onChange(fromEditable(nextHex, nextAlpha));
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button type="button" aria-label={label} className="flex items-center gap-2 text-left">
+          <span
+            className="h-5 w-5 rounded border border-border"
+            style={{ backgroundColor: value }}
+          />
+          <span className="text-[length:var(--ui-fs-metric-meta)]">{label}</span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="flex w-56 flex-col gap-2">
+        <input
+          type="color"
+          aria-label={`${label} picker`}
+          value={hex}
+          onInput={(e) => emit(e.target.value, alpha)}
+        />
+        <div className="flex items-center gap-2">
+          <Label htmlFor={`${label}-hex`}>Hex</Label>
+          <input
+            id={`${label}-hex`}
+            aria-label={`${label} hex`}
+            value={hex}
+            onInput={(e) => /^#[0-9a-f]{6}$/i.test(e.target.value) && emit(e.target.value, alpha)}
+            className="flex-1 rounded border border-input bg-transparent px-2 py-1"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <Label htmlFor={`${label}-alpha`}>Alpha</Label>
+          <input
+            id={`${label}-alpha`}
+            aria-label={`${label} alpha`}
+            type="range"
+            min="0"
+            max="1"
+            step="0.01"
+            value={alpha}
+            onInput={(e) => emit(hex, parseFloat(e.target.value))}
+            className="flex-1"
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/ColorControl.test.jsx
+++ b/src/components/ColorControl.test.jsx
@@ -1,0 +1,30 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ColorControl } from "./ColorControl.jsx";
+
+beforeEach(() => {
+  window.matchMedia = vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+});
+
+describe("ColorControl", () => {
+  it("shows the current color and emits hex at full alpha", () => {
+    const onChange = vi.fn();
+    render(<ColorControl label="Accent" value="#fb923c" onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /accent/i }));
+    fireEvent.input(screen.getByLabelText(/hex/i), { target: { value: "#22d3ee" } });
+    expect(onChange).toHaveBeenLastCalledWith("#22d3ee");
+  });
+  it("emits rgba when alpha < 1", () => {
+    const onChange = vi.fn();
+    render(<ColorControl label="Border" value="#ffffff" onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /border/i }));
+    fireEvent.input(screen.getByLabelText(/alpha/i), { target: { value: "0.5" } });
+    expect(onChange).toHaveBeenLastCalledWith("rgba(255, 255, 255, 0.5)");
+  });
+});

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -56,6 +56,11 @@ export function SettingsPanel({
   channelLabelHasOverride = false,
   setChannelLabelToken = () => {},
   resetChannelLabels = () => {},
+  customThemeOptions = [],
+  createCustomTheme = () => {},
+  editActiveCustomTheme = () => {},
+  deleteCustomTheme = () => {},
+  activeIsCustom = false,
 }) {
   const reduceMotion = useReducedMotion();
   const isMac =
@@ -248,8 +253,33 @@ export function SettingsPanel({
                             {opt.label}
                           </SelectItem>
                         ))}
+                        {customThemeOptions.map((opt) => (
+                          <SelectItem key={opt.id} value={opt.id}>
+                            {opt.label}
+                          </SelectItem>
+                        ))}
                       </SelectContent>
                     </Select>
+                    <div className="flex items-center gap-2">
+                      <Button size="sm" variant="ghost" onClick={createCustomTheme}>
+                        Duplicate
+                      </Button>
+                      {activeIsCustom ? (
+                        <>
+                          <Button size="sm" variant="ghost" onClick={editActiveCustomTheme}>
+                            Edit
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            className="text-destructive"
+                            onClick={() => deleteCustomTheme(fixedThemeSelectValue)}
+                          >
+                            Delete
+                          </Button>
+                        </>
+                      ) : null}
+                    </div>
                   </div>
                 ) : null}
                 <Separator />

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -61,6 +61,7 @@ export function SettingsPanel({
   editActiveCustomTheme = () => {},
   deleteCustomTheme = () => {},
   activeIsCustom = false,
+  themeControlsDisabled = false,
 }) {
   const reduceMotion = useReducedMotion();
   const isMac =
@@ -224,54 +225,98 @@ export function SettingsPanel({
                   ) : null}
                 </div>
                 <Separator />
-                <div className="flex items-center justify-between gap-2">
-                  <Label htmlFor="settings-appearance" className="shrink-0">
-                    Appearance
-                  </Label>
-                  <Select value={appearance} onValueChange={setAppearanceMode}>
-                    <SelectTrigger id="settings-appearance" className="w-auto shrink-0">
-                      <SelectValue placeholder="Appearance" />
-                    </SelectTrigger>
-                    <SelectContent position="popper">
-                      <SelectItem value="system">Follow System</SelectItem>
-                      <SelectItem value="fixed">Fixed Theme</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                {appearance === "fixed" ? (
+                <div className="flex flex-col gap-2">
+                  {themeControlsDisabled ? (
+                    <span className="text-xs text-muted-foreground">
+                      Finish editing the current theme before changing theme settings.
+                    </span>
+                  ) : null}
                   <div className="flex items-center justify-between gap-2">
-                    <Label htmlFor="settings-theme-id" className="shrink-0">
-                      Colour Theme
+                    <Label htmlFor="settings-appearance" className="shrink-0">
+                      Appearance
                     </Label>
-                    <Select value={fixedThemeSelectValue} onValueChange={setFixedThemeIdFromPicker}>
-                      <SelectTrigger id="settings-theme-id" className="w-auto shrink-0">
-                        <SelectValue placeholder="Theme" />
+                    <Select
+                      value={appearance}
+                      onValueChange={setAppearanceMode}
+                      disabled={themeControlsDisabled}
+                    >
+                      <SelectTrigger
+                        id="settings-appearance"
+                        className="w-auto shrink-0"
+                        disabled={themeControlsDisabled}
+                      >
+                        <SelectValue placeholder="Appearance" />
                       </SelectTrigger>
                       <SelectContent position="popper">
-                        {themeSelectOptions.map((opt) => (
-                          <SelectItem key={opt.id} value={opt.id}>
-                            {opt.label}
-                          </SelectItem>
-                        ))}
-                        {customThemeOptions.map((opt) => (
-                          <SelectItem key={opt.id} value={opt.id}>
-                            {opt.label}
-                          </SelectItem>
-                        ))}
+                        <SelectItem value="system">Follow System</SelectItem>
+                        <SelectItem value="fixed">Fixed Theme</SelectItem>
                       </SelectContent>
                     </Select>
-                    <div className="flex items-center gap-2">
-                      <Button size="sm" variant="ghost" onClick={createCustomTheme}>
-                        Duplicate
+                  </div>
+                </div>
+                {appearance === "fixed" ? (
+                  <div className="flex flex-col gap-2">
+                    <div
+                      role="group"
+                      aria-label="Theme picker"
+                      className="flex items-center justify-between gap-2"
+                    >
+                      <Label htmlFor="settings-theme-id" className="shrink-0">
+                        Colour Theme
+                      </Label>
+                      <Select
+                        value={fixedThemeSelectValue}
+                        onValueChange={setFixedThemeIdFromPicker}
+                        disabled={themeControlsDisabled}
+                      >
+                        <SelectTrigger
+                          id="settings-theme-id"
+                          className="w-auto shrink-0"
+                          disabled={themeControlsDisabled}
+                        >
+                          <SelectValue placeholder="Theme" />
+                        </SelectTrigger>
+                        <SelectContent position="popper">
+                          {themeSelectOptions.map((opt) => (
+                            <SelectItem key={opt.id} value={opt.id}>
+                              {opt.label}
+                            </SelectItem>
+                          ))}
+                          {customThemeOptions.map((opt) => (
+                            <SelectItem key={opt.id} value={opt.id}>
+                              {opt.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div
+                      role="group"
+                      aria-label="Theme actions"
+                      className="flex items-center justify-end gap-2"
+                    >
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={themeControlsDisabled}
+                        onClick={createCustomTheme}
+                      >
+                        Add New Theme
                       </Button>
                       {activeIsCustom ? (
                         <>
-                          <Button size="sm" variant="ghost" onClick={editActiveCustomTheme}>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            disabled={themeControlsDisabled}
+                            onClick={editActiveCustomTheme}
+                          >
                             Edit
                           </Button>
                           <Button
                             size="sm"
                             variant="ghost"
+                            disabled={themeControlsDisabled}
                             className="text-destructive"
                             onClick={() => deleteCustomTheme(fixedThemeSelectValue)}
                           >

--- a/src/components/SettingsPanel.test.jsx
+++ b/src/components/SettingsPanel.test.jsx
@@ -45,6 +45,57 @@ describe("SettingsPanel", () => {
     expect(screen.getByLabelText("Colour Theme")).toBeTruthy();
   });
 
+  it("keeps custom theme actions on their own row", () => {
+    render(
+      <SettingsPanel
+        {...BASE_PROPS}
+        appearance="fixed"
+        fixedThemeSelectValue="custom-1"
+        customThemeOptions={[{ id: "custom-1", label: "Custom Theme" }]}
+        activeIsCustom={true}
+      />
+    );
+
+    const themePicker = screen.getByRole("group", { name: "Theme picker" });
+    const themeActions = screen.getByRole("group", { name: "Theme actions" });
+
+    expect(themePicker.textContent).toContain("Colour Theme");
+    expect(themePicker.textContent).not.toContain("Add New Theme");
+    expect(themePicker.textContent).not.toContain("Edit");
+    expect(themePicker.textContent).not.toContain("Delete");
+    expect(themeActions.textContent).toContain("Add New Theme");
+    expect(themeActions.textContent).toContain("Edit");
+    expect(themeActions.textContent).toContain("Delete");
+    expect(screen.queryByRole("button", { name: "Duplicate" })).toBeNull();
+  });
+
+  it("locks theme controls while the theme editor is open", () => {
+    render(
+      <SettingsPanel
+        {...BASE_PROPS}
+        appearance="fixed"
+        fixedThemeSelectValue="custom-1"
+        customThemeOptions={[{ id: "custom-1", label: "Custom Theme" }]}
+        activeIsCustom={true}
+        themeControlsDisabled={true}
+      />
+    );
+
+    const themeLockHint = screen.getByText(
+      "Finish editing the current theme before changing theme settings."
+    );
+    const appearanceSelect = screen.getByLabelText("Appearance");
+
+    expect(themeLockHint.compareDocumentPosition(appearanceSelect)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
+    expect(appearanceSelect.disabled).toBe(true);
+    expect(screen.getByLabelText("Colour Theme").disabled).toBe(true);
+    expect(screen.getByRole("button", { name: "Add New Theme" }).disabled).toBe(true);
+    expect(screen.getByRole("button", { name: "Edit" }).disabled).toBe(true);
+    expect(screen.getByRole("button", { name: "Delete" }).disabled).toBe(true);
+  });
+
   it("does not render panel-specific channel selectors", () => {
     render(
       <SettingsPanel

--- a/src/components/StatusPill.jsx
+++ b/src/components/StatusPill.jsx
@@ -11,13 +11,14 @@ const STATE_CONFIG = {
     dotGlow: "",
   },
   live: {
-    bg: "bg-red-500/8",
-    border: "border border-red-400/30",
-    color: "text-red-400",
+    bg: "bg-[color:color-mix(in_srgb,var(--ui-signal-bad)_8%,transparent)]",
+    border: "border border-[color:color-mix(in_srgb,var(--ui-signal-bad)_30%,transparent)]",
+    color: "text-[color:var(--ui-signal-bad)]",
     label: "LIVE",
     showClock: () => true,
     dotPulse: true,
-    dotGlow: "shadow-[0_0_0_3px_rgba(248,113,113,0.18),0_0_6px_rgb(248,113,113)]",
+    dotGlow:
+      "shadow-[0_0_0_3px_color-mix(in_srgb,var(--ui-signal-bad)_18%,transparent),0_0_6px_var(--ui-signal-bad)]",
   },
   snapshot: {
     bg: "bg-amber-500/8",

--- a/src/components/StatusPill.jsx
+++ b/src/components/StatusPill.jsx
@@ -21,9 +21,9 @@ const STATE_CONFIG = {
       "shadow-[0_0_0_3px_color-mix(in_srgb,var(--ui-signal-bad)_18%,transparent),0_0_6px_var(--ui-signal-bad)]",
   },
   snapshot: {
-    bg: "bg-amber-500/8",
-    border: "border border-amber-400/30",
-    color: "text-amber-400",
+    bg: "bg-[color:color-mix(in_srgb,var(--ui-signal-warn)_8%,transparent)]",
+    border: "border border-[color:color-mix(in_srgb,var(--ui-signal-warn)_30%,transparent)]",
+    color: "text-[color:var(--ui-signal-warn)]",
     label: "SNAP",
     showClock: (clock) => clock != null,
     dotPulse: false,

--- a/src/components/ThemeEditor.jsx
+++ b/src/components/ThemeEditor.jsx
@@ -21,8 +21,9 @@ const SHELL_GROUPS = [
     ],
   },
   {
+    // primary + ring are not listed: they follow the accent seed (see buildThemeTokens), not the shell.
     title: "Brand",
-    keys: ["primary", "primaryForeground", "ring", "destructive", "destructiveForeground"],
+    keys: ["primaryForeground", "destructive", "destructiveForeground"],
   },
   { title: "Lines", keys: ["border", "input"] },
 ];
@@ -36,6 +37,7 @@ const SHELL_GROUPS = [
  *   onSave: () => void,
  *   onCancel: () => void,
  *   onDelete?: () => void,
+ *   dirty?: boolean,
  *   pos: {x:number,y:number},
  *   onMove: (p: {x:number,y:number}) => void,
  * }} props
@@ -48,9 +50,13 @@ export function ThemeEditor({
   onSave,
   onCancel,
   onDelete,
+  dirty,
   pos,
   onMove,
 }) {
+  function handleCancel() {
+    if (!dirty || window.confirm("Discard changes and revert to the previous theme?")) onCancel();
+  }
   const ref = useRef(null);
   const dragRef = useRef(null);
 
@@ -157,7 +163,7 @@ export function ThemeEditor({
           <span />
         )}
         <div className="flex gap-2">
-          <Button variant="ghost" onClick={onCancel}>
+          <Button variant="ghost" onClick={handleCancel}>
             Cancel
           </Button>
           <Button onClick={onSave}>Save</Button>

--- a/src/components/ThemeEditor.jsx
+++ b/src/components/ThemeEditor.jsx
@@ -1,4 +1,5 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { ColorControl } from "./ColorControl.jsx";
@@ -54,9 +55,21 @@ export function ThemeEditor({
   pos,
   onMove,
 }) {
+  const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
+
   function handleCancel() {
-    if (!dirty || window.confirm("Discard changes and revert to the previous theme?")) onCancel();
+    if (!dirty) {
+      onCancel();
+      return;
+    }
+    setDiscardDialogOpen(true);
   }
+
+  function handleDiscardChanges() {
+    setDiscardDialogOpen(false);
+    onCancel();
+  }
+
   const ref = useRef(null);
   const dragRef = useRef(null);
 
@@ -86,89 +99,112 @@ export function ThemeEditor({
   }
 
   return (
-    <div
-      ref={ref}
-      role="dialog"
-      aria-label="Theme editor"
-      className="fixed z-50 flex max-h-[80vh] w-80 flex-col gap-2 overflow-hidden rounded-[var(--ui-radius-modal)] border border-border bg-card text-card-foreground shadow-lg"
-      style={{ left: pos.x, top: pos.y }}
-    >
+    <>
       <div
-        onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
-        onPointerUp={onPointerUp}
-        className="flex cursor-move items-center justify-between border-b border-border px-3 py-2"
+        ref={ref}
+        role="dialog"
+        aria-label="Theme editor"
+        className="fixed z-50 flex max-h-[80vh] w-80 flex-col gap-2 overflow-hidden rounded-[var(--ui-radius-modal)] border border-border bg-card text-card-foreground shadow-lg"
+        style={{ left: pos.x, top: pos.y }}
       >
-        <input
-          aria-label="Theme name"
-          value={draft.name}
-          onInput={(e) => onName(e.target.value)}
-          className="bg-transparent text-[length:var(--ui-fs-panel-title)] font-semibold"
-        />
-        <span className="text-[length:var(--ui-fs-status)] text-muted-foreground">
-          {draft.colorScheme}
-        </span>
-      </div>
+        <div
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          className="flex cursor-move items-center justify-between border-b border-border px-3 py-2"
+        >
+          <input
+            aria-label="Theme name"
+            value={draft.name}
+            onInput={(e) => onName(e.target.value)}
+            className="bg-transparent text-[length:var(--ui-fs-panel-title)] font-semibold"
+          />
+        </div>
 
-      <div className="flex flex-col gap-3 overflow-y-auto px-3 py-2">
-        <section className="flex flex-col gap-1.5">
-          <Label>Seeds</Label>
-          <ColorControl
-            label="Accent"
-            value={draft.seeds.accent}
-            onChange={(c) => onSeed("accent", c)}
-          />
-          <ColorControl
-            label="Accent 2"
-            value={draft.seeds.accentSecondary}
-            onChange={(c) => onSeed("accentSecondary", c)}
-          />
-          <ColorControl
-            label="Signal Good"
-            value={draft.seeds.signal.good}
-            onChange={(c) => onSeed("good", c)}
-          />
-          <ColorControl
-            label="Signal Warn"
-            value={draft.seeds.signal.warn}
-            onChange={(c) => onSeed("warn", c)}
-          />
-          <ColorControl
-            label="Signal Bad"
-            value={draft.seeds.signal.bad}
-            onChange={(c) => onSeed("bad", c)}
-          />
-        </section>
-        {SHELL_GROUPS.map((g) => (
-          <section key={g.title} className="flex flex-col gap-1.5">
-            <Label>{g.title}</Label>
-            {g.keys.map((k) => (
-              <ColorControl
-                key={k}
-                label={k}
-                value={draft.semantic[k]}
-                onChange={(c) => onShell(k, c)}
-              />
-            ))}
+        <div className="flex flex-col gap-3 overflow-y-auto px-3 py-2">
+          <section className="flex flex-col gap-1.5">
+            <Label>Seeds</Label>
+            <ColorControl
+              label="Accent"
+              value={draft.seeds.accent}
+              onChange={(c) => onSeed("accent", c)}
+            />
+            <ColorControl
+              label="Accent 2"
+              value={draft.seeds.accentSecondary}
+              onChange={(c) => onSeed("accentSecondary", c)}
+            />
+            <ColorControl
+              label="Signal Good"
+              value={draft.seeds.signal.good}
+              onChange={(c) => onSeed("good", c)}
+            />
+            <ColorControl
+              label="Signal Warn"
+              value={draft.seeds.signal.warn}
+              onChange={(c) => onSeed("warn", c)}
+            />
+            <ColorControl
+              label="Signal Bad"
+              value={draft.seeds.signal.bad}
+              onChange={(c) => onSeed("bad", c)}
+            />
           </section>
-        ))}
-      </div>
+          {SHELL_GROUPS.map((g) => (
+            <section key={g.title} className="flex flex-col gap-1.5">
+              <Label>{g.title}</Label>
+              {g.keys.map((k) => (
+                <ColorControl
+                  key={k}
+                  label={k}
+                  value={draft.semantic[k]}
+                  onChange={(c) => onShell(k, c)}
+                />
+              ))}
+            </section>
+          ))}
+        </div>
 
-      <div className="flex items-center justify-between gap-2 border-t border-border px-3 py-2">
-        {onDelete ? (
-          <Button variant="ghost" onClick={onDelete} className="text-destructive">
-            Delete
-          </Button>
-        ) : (
-          <span />
-        )}
-        <div className="flex gap-2">
-          <Button variant="ghost" onClick={handleCancel}>
-            Cancel
-          </Button>
-          <Button onClick={onSave}>Save</Button>
+        <div className="flex items-center justify-between gap-2 border-t border-border px-3 py-2">
+          {onDelete ? (
+            <Button variant="ghost" onClick={onDelete} className="text-destructive">
+              Delete
+            </Button>
+          ) : (
+            <span />
+          )}
+          <div className="flex gap-2">
+            <Button variant="ghost" onClick={handleCancel}>
+              Cancel
+            </Button>
+            <Button onClick={onSave}>Save</Button>
+          </div>
         </div>
       </div>
-    </div>
+      <Dialog.Root open={discardDialogOpen} onOpenChange={setDiscardDialogOpen}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 z-[60] bg-black/60" />
+          <Dialog.Content
+            role="alertdialog"
+            className="fixed left-1/2 top-1/2 z-[61] w-80 -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-card p-6 text-card-foreground shadow-xl focus:outline-none"
+          >
+            <Dialog.Title className="mb-3 text-sm font-semibold text-foreground">
+              Discard theme changes?
+            </Dialog.Title>
+            <Dialog.Description className="mb-6 text-sm text-muted-foreground">
+              Unsaved edits will be discarded and the previous theme will be restored.
+            </Dialog.Description>
+            <div className="flex justify-end gap-2">
+              <Button variant="ghost" onClick={() => setDiscardDialogOpen(false)}>
+                Keep Editing
+              </Button>
+              <Button variant="destructive" onClick={handleDiscardChanges}>
+                Discard Changes
+              </Button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </>
   );
 }

--- a/src/components/ThemeEditor.jsx
+++ b/src/components/ThemeEditor.jsx
@@ -1,0 +1,168 @@
+import { useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { ColorControl } from "./ColorControl.jsx";
+import { clampPanelPos } from "../lib/dragClamp.js";
+
+const SHELL_GROUPS = [
+  {
+    title: "Surface",
+    keys: ["background", "card", "popover", "secondary", "muted", "accent"],
+  },
+  {
+    title: "Text",
+    keys: [
+      "foreground",
+      "cardForeground",
+      "popoverForeground",
+      "mutedForeground",
+      "secondaryForeground",
+      "accentForeground",
+    ],
+  },
+  {
+    title: "Brand",
+    keys: ["primary", "primaryForeground", "ring", "destructive", "destructiveForeground"],
+  },
+  { title: "Lines", keys: ["border", "input"] },
+];
+
+/**
+ * @param {{
+ *   draft: object,
+ *   onName: (s: string) => void,
+ *   onSeed: (key: string, css: string) => void,
+ *   onShell: (key: string, css: string) => void,
+ *   onSave: () => void,
+ *   onCancel: () => void,
+ *   onDelete?: () => void,
+ *   pos: {x:number,y:number},
+ *   onMove: (p: {x:number,y:number}) => void,
+ * }} props
+ */
+export function ThemeEditor({
+  draft,
+  onName,
+  onSeed,
+  onShell,
+  onSave,
+  onCancel,
+  onDelete,
+  pos,
+  onMove,
+}) {
+  const ref = useRef(null);
+  const dragRef = useRef(null);
+
+  function onPointerDown(e) {
+    const rect = ref.current.getBoundingClientRect();
+    dragRef.current = {
+      dx: e.clientX - rect.left,
+      dy: e.clientY - rect.top,
+      w: rect.width,
+      h: rect.height,
+    };
+    e.currentTarget.setPointerCapture(e.pointerId);
+  }
+  function onPointerMove(e) {
+    const d = dragRef.current;
+    if (!d) return;
+    onMove(
+      clampPanelPos(
+        { x: e.clientX - d.dx, y: e.clientY - d.dy },
+        { w: d.w, h: d.h },
+        { w: window.innerWidth, h: window.innerHeight }
+      )
+    );
+  }
+  function onPointerUp() {
+    dragRef.current = null;
+  }
+
+  return (
+    <div
+      ref={ref}
+      role="dialog"
+      aria-label="Theme editor"
+      className="fixed z-50 flex max-h-[80vh] w-80 flex-col gap-2 overflow-hidden rounded-[var(--ui-radius-modal)] border border-border bg-card text-card-foreground shadow-lg"
+      style={{ left: pos.x, top: pos.y }}
+    >
+      <div
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        className="flex cursor-move items-center justify-between border-b border-border px-3 py-2"
+      >
+        <input
+          aria-label="Theme name"
+          value={draft.name}
+          onInput={(e) => onName(e.target.value)}
+          className="bg-transparent text-[length:var(--ui-fs-panel-title)] font-semibold"
+        />
+        <span className="text-[length:var(--ui-fs-status)] text-muted-foreground">
+          {draft.colorScheme}
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-3 overflow-y-auto px-3 py-2">
+        <section className="flex flex-col gap-1.5">
+          <Label>Seeds</Label>
+          <ColorControl
+            label="Accent"
+            value={draft.seeds.accent}
+            onChange={(c) => onSeed("accent", c)}
+          />
+          <ColorControl
+            label="Accent 2"
+            value={draft.seeds.accentSecondary}
+            onChange={(c) => onSeed("accentSecondary", c)}
+          />
+          <ColorControl
+            label="Signal Good"
+            value={draft.seeds.signal.good}
+            onChange={(c) => onSeed("good", c)}
+          />
+          <ColorControl
+            label="Signal Warn"
+            value={draft.seeds.signal.warn}
+            onChange={(c) => onSeed("warn", c)}
+          />
+          <ColorControl
+            label="Signal Bad"
+            value={draft.seeds.signal.bad}
+            onChange={(c) => onSeed("bad", c)}
+          />
+        </section>
+        {SHELL_GROUPS.map((g) => (
+          <section key={g.title} className="flex flex-col gap-1.5">
+            <Label>{g.title}</Label>
+            {g.keys.map((k) => (
+              <ColorControl
+                key={k}
+                label={k}
+                value={draft.semantic[k]}
+                onChange={(c) => onShell(k, c)}
+              />
+            ))}
+          </section>
+        ))}
+      </div>
+
+      <div className="flex items-center justify-between gap-2 border-t border-border px-3 py-2">
+        {onDelete ? (
+          <Button variant="ghost" onClick={onDelete} className="text-destructive">
+            Delete
+          </Button>
+        ) : (
+          <span />
+        )}
+        <div className="flex gap-2">
+          <Button variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button onClick={onSave}>Save</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ThemeEditor.test.jsx
+++ b/src/components/ThemeEditor.test.jsx
@@ -1,0 +1,53 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ThemeEditor } from "./ThemeEditor.jsx";
+import { makeCustomThemeFromBase } from "../theme/customTheme.js";
+import { BUILTIN_THEMES } from "../theme/builtinThemes.js";
+
+const DRAFT = makeCustomThemeFromBase(BUILTIN_THEMES["plvs-dark"], "My Theme", () => "custom-1");
+
+const BASE_PROPS = {
+  draft: DRAFT,
+  onName: vi.fn(),
+  onSeed: vi.fn(),
+  onShell: vi.fn(),
+  onSave: vi.fn(),
+  onCancel: vi.fn(),
+  dirty: false,
+  pos: { x: 10, y: 20 },
+  onMove: vi.fn(),
+};
+
+describe("ThemeEditor", () => {
+  it("does not show the custom theme color scheme in the title bar", () => {
+    render(<ThemeEditor {...BASE_PROPS} />);
+
+    const dialog = screen.getByRole("dialog", { name: "Theme editor" });
+
+    expect(dialog.textContent).not.toContain("dark");
+    expect(dialog.textContent).not.toContain("light");
+  });
+
+  it("uses an app dialog when cancelling dirty edits", () => {
+    const onCancel = vi.fn();
+    const confirmSpy = vi.spyOn(window, "confirm");
+
+    render(<ThemeEditor {...BASE_PROPS} dirty={true} onCancel={onCancel} />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(screen.getByRole("alertdialog", { name: "Discard theme changes?" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Keep Editing" }));
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alertdialog", { name: "Discard theme changes?" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    fireEvent.click(screen.getByRole("button", { name: "Discard Changes" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+
+    confirmSpy.mockRestore();
+  });
+});

--- a/src/components/TransportButton.jsx
+++ b/src/components/TransportButton.jsx
@@ -14,7 +14,8 @@ const STATE_CONFIG = {
     label: "STOP",
   },
   snapshot: {
-    className: "bg-transparent text-amber-400 border border-amber-400/40 hover:bg-amber-400/8",
+    className:
+      "bg-transparent text-[color:var(--ui-signal-warn)] border border-[color:color-mix(in_srgb,var(--ui-signal-warn)_40%,transparent)] hover:bg-[color:color-mix(in_srgb,var(--ui-signal-warn)_8%,transparent)]",
     Icon: Radio,
     label: "LIVE",
   },

--- a/src/components/TransportButton.jsx
+++ b/src/components/TransportButton.jsx
@@ -8,7 +8,8 @@ const STATE_CONFIG = {
     label: "START",
   },
   live: {
-    className: "bg-transparent text-red-400 border border-red-400/40 hover:bg-red-400/8",
+    className:
+      "bg-transparent text-[color:var(--ui-signal-bad)] border border-[color:color-mix(in_srgb,var(--ui-signal-bad)_40%,transparent)] hover:bg-[color:color-mix(in_srgb,var(--ui-signal-bad)_8%,transparent)]",
     Icon: Square,
     label: "STOP",
   },

--- a/src/components/panels/SpectrogramPanel.jsx
+++ b/src/components/panels/SpectrogramPanel.jsx
@@ -11,7 +11,8 @@ import { HelpPopover } from "../HelpPopover";
 import { useChartHover } from "../../hooks/useChartHover";
 import { computeSpectrogramHoverPoint } from "../../math/hoverMath";
 import { VISUAL_HIST_SAMPLE_SEC } from "../../hooks/useLoudnessHistory.js";
-import { getBuiltinTheme } from "../../theme/builtinThemes.js";
+import { getTheme } from "../../theme/themeRegistry.js";
+import { listCustomThemes } from "../../theme/customThemesRepo.js";
 import { buildSpectrogramLut } from "../../theme/spectrogramColormap.js";
 
 const SPECTROGRAM_HELP = [
@@ -67,7 +68,7 @@ export function SpectrogramPanel({ compact = false }) {
   const spectrogramSnaps =
     selectedOffset >= 0 ? (visualSpectrogramSnap ?? []) : (snapRef.current ?? []);
   const colormapLut = useMemo(
-    () => buildSpectrogramLut(getBuiltinTheme(resolvedThemeId).colormap),
+    () => buildSpectrogramLut(getTheme(resolvedThemeId, listCustomThemes()).colormap),
     [resolvedThemeId]
   );
   const visualViewport = useMemo(

--- a/src/components/panels/WaveformPanel.jsx
+++ b/src/components/panels/WaveformPanel.jsx
@@ -113,6 +113,7 @@ export function WaveformPanel({ compact = false }) {
             firstBucket={firstBucket}
             lastBucket={lastBucket}
             compact={compact}
+            selected={selectedOffset >= 0}
           />
         ))}
 
@@ -236,6 +237,7 @@ function WaveformLane({
   firstBucket,
   lastBucket,
   compact,
+  selected,
 }) {
   const canvasRef = useRef(null);
   const containerRef = useRef(null);
@@ -269,7 +271,10 @@ function WaveformLane({
     const style = getComputedStyle(document.documentElement);
     const zeroLineColor =
       style.getPropertyValue("--ui-loudness-grid").trim() || "rgba(128,128,128,0.18)";
-    const strokeColor = style.getPropertyValue("--ui-waveform-trace").trim() || "#fb923c";
+    const strokeColor =
+      (selected
+        ? style.getPropertyValue("--ui-waveform-trace-snap").trim()
+        : style.getPropertyValue("--ui-waveform-trace").trim()) || "#fb923c";
     const fillOpacity =
       parseFloat(style.getPropertyValue("--ui-waveform-fill-opacity").trim()) || 0.22;
 
@@ -310,7 +315,7 @@ function WaveformLane({
     ctx.strokeStyle = strokeColor;
     ctx.lineWidth = window.devicePixelRatio || 1;
     ctx.stroke();
-  }, [mins, maxes, bucketCount, fracPhase, firstBucket, lastBucket, canvasSize]);
+  }, [mins, maxes, bucketCount, fracPhase, firstBucket, lastBucket, canvasSize, selected]);
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 items-stretch">

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -140,6 +140,8 @@ export function useSettings({ onClearRef } = {}) {
     prevSelection: { appearance, themeId },
     setThemeId,
     setAppearance,
+    // pluginStore.subscribe is a no-op, so refresh the list explicitly after editor mutations.
+    onChange: () => setCustomThemes(listCustomThemes()),
   });
 
   const customThemeOptions = useMemo(

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -155,7 +155,7 @@ export function useSettings({ onClearRef } = {}) {
   }
   function createCustomTheme() {
     setSettingsOpen(false);
-    editor.beginCreate(`${getTheme(resolvedThemeId, customThemes).label ?? "Theme"} copy`);
+    editor.beginCreate("Custom");
   }
   function editActiveCustomTheme() {
     if (!isCustomThemeId(resolvedThemeId)) return;

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -7,9 +7,15 @@ import {
   readSystemPrefersDark,
   resolveThemeId,
 } from "../uiPreferences";
-import { isThemeId, THEME_SELECT_OPTIONS } from "../theme/builtinThemes.js";
-import { listCustomThemes } from "../theme/customThemesRepo.js";
-import { isKnownThemeId } from "../theme/themeRegistry.js";
+import { THEME_SELECT_OPTIONS } from "../theme/builtinThemes.js";
+import {
+  listCustomThemes,
+  listCustomThemesOrdered,
+  removeCustomTheme,
+} from "../theme/customThemesRepo.js";
+import { getTheme, isKnownThemeId } from "../theme/themeRegistry.js";
+import { isCustomThemeId } from "../theme/customTheme.js";
+import { useThemeEditor } from "./useThemeEditor.js";
 import { useAutostart } from "./useAutostart.js";
 import { useClearShortcut } from "./useClearShortcut.js";
 import { normalizeFocusView } from "../lib/focusView.js";
@@ -39,6 +45,9 @@ export function useSettings({ onClearRef } = {}) {
   const clearShortcutState = useClearShortcut(onClearRef);
 
   const [customThemes, setCustomThemes] = useState(() => listCustomThemes());
+  const [editorPos, setEditorPos] = useState(
+    () => settingsStore.read().themeEditorPos ?? { x: 80, y: 80 }
+  );
 
   const resolvedThemeId = useMemo(
     () => resolveThemeId({ appearance, themeId }, systemPrefersDark, customThemes),
@@ -58,7 +67,7 @@ export function useSettings({ onClearRef } = {}) {
   }
 
   function setFixedThemeIdFromPicker(id) {
-    if (!isThemeId(id)) return;
+    if (!isKnownThemeId(id, customThemes)) return;
     setAppearance("fixed");
     setThemeId(id);
   }
@@ -120,6 +129,43 @@ export function useSettings({ onClearRef } = {}) {
 
   useEffect(() => themesStore.subscribe(() => setCustomThemes(listCustomThemes())), []);
 
+  function moveEditor(pos) {
+    setEditorPos(pos);
+    settingsStore.patch({ themeEditorPos: pos });
+  }
+
+  const editor = useThemeEditor({
+    activeTheme: getTheme(resolvedThemeId, customThemes),
+    customThemes,
+    prevSelection: { appearance, themeId },
+    setThemeId,
+    setAppearance,
+  });
+
+  const customThemeOptions = useMemo(
+    () => listCustomThemesOrdered().map((t) => ({ id: t.id, label: t.name })),
+    [customThemes]
+  );
+
+  function selectThemeId(id) {
+    setAppearance("fixed");
+    setThemeId(id);
+  }
+  function createCustomTheme() {
+    setSettingsOpen(false);
+    editor.beginCreate(`${getTheme(resolvedThemeId, customThemes).label ?? "Theme"} copy`);
+  }
+  function editActiveCustomTheme() {
+    if (!isCustomThemeId(resolvedThemeId)) return;
+    setSettingsOpen(false);
+    editor.beginEdit(getTheme(resolvedThemeId, customThemes));
+  }
+  function deleteCustomTheme(id) {
+    removeCustomTheme(id);
+    setCustomThemes(listCustomThemes());
+    if (themeId === id) selectThemeId("plvs-dark");
+  }
+
   return {
     settingsOpen,
     setSettingsOpen,
@@ -143,6 +189,14 @@ export function useSettings({ onClearRef } = {}) {
     autostartEnabled,
     setAutostartEnabled,
     autostartReady,
+    editor,
+    editorPos,
+    moveEditor,
+    customThemeOptions,
+    createCustomTheme,
+    editActiveCustomTheme,
+    deleteCustomTheme,
+    activeIsCustom: isCustomThemeId(resolvedThemeId),
     ...clearShortcutState,
   };
 }

--- a/src/hooks/useSettings.js
+++ b/src/hooks/useSettings.js
@@ -8,10 +8,12 @@ import {
   resolveThemeId,
 } from "../uiPreferences";
 import { isThemeId, THEME_SELECT_OPTIONS } from "../theme/builtinThemes.js";
+import { listCustomThemes } from "../theme/customThemesRepo.js";
+import { isKnownThemeId } from "../theme/themeRegistry.js";
 import { useAutostart } from "./useAutostart.js";
 import { useClearShortcut } from "./useClearShortcut.js";
 import { normalizeFocusView } from "../lib/focusView.js";
-import { presetsStore, settingsStore } from "../persistence/index.js";
+import { presetsStore, settingsStore, themesStore } from "../persistence/index.js";
 
 function normalizeReferenceLufs(raw) {
   const n = Number(raw);
@@ -36,9 +38,11 @@ export function useSettings({ onClearRef } = {}) {
   const { autostartEnabled, setAutostartEnabled, autostartReady } = useAutostart();
   const clearShortcutState = useClearShortcut(onClearRef);
 
+  const [customThemes, setCustomThemes] = useState(() => listCustomThemes());
+
   const resolvedThemeId = useMemo(
-    () => resolveThemeId({ appearance, themeId }, systemPrefersDark),
-    [appearance, themeId, systemPrefersDark]
+    () => resolveThemeId({ appearance, themeId }, systemPrefersDark, customThemes),
+    [appearance, themeId, systemPrefersDark, customThemes]
   );
   /** ADR 0002 §6: switching system → fixed seeds `themeId` from the resolved builtin at that moment. */
   function setAppearanceMode(mode) {
@@ -61,8 +65,8 @@ export function useSettings({ onClearRef } = {}) {
 
   const fixedThemeSelectValue = useMemo(() => {
     if (appearance !== "fixed") return "";
-    return isThemeId(themeId) ? themeId : resolvedThemeId;
-  }, [appearance, themeId, resolvedThemeId]);
+    return isKnownThemeId(themeId, customThemes) ? themeId : resolvedThemeId;
+  }, [appearance, themeId, resolvedThemeId, customThemes]);
 
   function setCloseAction(value) {
     if (value === "ask") {
@@ -100,8 +104,8 @@ export function useSettings({ onClearRef } = {}) {
 
   useEffect(() => {
     applyLayoutToDocument(UI_PREFERENCES);
-    applyThemeToDocument(resolvedThemeId);
-  }, [resolvedThemeId]);
+    applyThemeToDocument(resolvedThemeId, customThemes);
+  }, [resolvedThemeId, customThemes]);
 
   useEffect(
     () =>
@@ -113,6 +117,8 @@ export function useSettings({ onClearRef } = {}) {
       }),
     []
   );
+
+  useEffect(() => themesStore.subscribe(() => setCustomThemes(listCustomThemes())), []);
 
   return {
     settingsOpen,

--- a/src/hooks/useSettings.rtl.test.jsx
+++ b/src/hooks/useSettings.rtl.test.jsx
@@ -45,6 +45,19 @@ describe("useSettings", () => {
     expect(result.current.themeId).toBe("plvs-light");
   });
 
+  it("names newly-created custom themes Custom by default", async () => {
+    const { result } = renderHook(() => useSettings());
+    await waitFor(() => {
+      expect(result.current.resolvedThemeId).toBe("plvs-dark");
+    });
+
+    act(() => {
+      result.current.createCustomTheme();
+    });
+
+    expect(result.current.editor.draft.name).toBe("Custom");
+  });
+
   it("defaults referenceLufs to -23 when localStorage is empty", () => {
     localStorage.clear();
     const { result } = renderHook(() => useSettings());

--- a/src/hooks/useThemeEditor.js
+++ b/src/hooks/useThemeEditor.js
@@ -1,0 +1,117 @@
+import { useCallback, useRef, useState } from "react";
+import { applyThemeToDocument } from "../uiPreferences";
+import { makeCustomThemeFromBase } from "../theme/customTheme.js";
+import {
+  listCustomThemes,
+  upsertCustomTheme,
+  removeCustomTheme,
+} from "../theme/customThemesRepo.js";
+
+/**
+ * @param {{
+ *   activeTheme: object,
+ *   customThemes: Record<string, object>,
+ *   prevSelection: { appearance: string, themeId: string|null },
+ *   setThemeId: (id: string) => void,
+ *   setAppearance: (a: string) => void,
+ *   apply?: (id: string, customThemes: Record<string, object>) => void,
+ *   makeId?: () => string,
+ * }} opts
+ */
+export function useThemeEditor(opts) {
+  const apply = opts.apply ?? applyThemeToDocument;
+  const [draft, setDraft] = useState(/** @type {object|null} */ (null));
+  const wasNewRef = useRef(false);
+  const prevRef = useRef(opts.prevSelection);
+
+  const applyDraft = useCallback(
+    (next) => apply(next.id, { ...listCustomThemes(), [next.id]: next }),
+    [apply]
+  );
+
+  const beginEdit = useCallback(
+    (theme) => {
+      wasNewRef.current = false;
+      prevRef.current = { appearance: "fixed", themeId: theme.id };
+      const d = structuredClone(theme);
+      setDraft(d);
+      applyDraft(d);
+    },
+    [applyDraft]
+  );
+
+  const beginCreate = useCallback(
+    (name) => {
+      wasNewRef.current = true;
+      prevRef.current = opts.prevSelection;
+      const d = makeCustomThemeFromBase(opts.activeTheme, name, opts.makeId);
+      upsertCustomTheme(d);
+      opts.setAppearance("fixed");
+      opts.setThemeId(d.id);
+      setDraft(d);
+      applyDraft(d);
+    },
+    [opts, applyDraft]
+  );
+
+  const setName = useCallback((name) => {
+    setDraft((d) => (d ? { ...d, name: String(name) } : d));
+  }, []);
+
+  const updateSeed = useCallback(
+    (key, value) => {
+      setDraft((d) => {
+        if (!d) return d;
+        const next =
+          key === "good" || key === "warn" || key === "bad"
+            ? { ...d, seeds: { ...d.seeds, signal: { ...d.seeds.signal, [key]: value } } }
+            : { ...d, seeds: { ...d.seeds, [key]: value } };
+        applyDraft(next);
+        return next;
+      });
+    },
+    [applyDraft]
+  );
+
+  const updateShell = useCallback(
+    (key, value) => {
+      setDraft((d) => {
+        if (!d) return d;
+        const next = { ...d, semantic: { ...d.semantic, [key]: value } };
+        applyDraft(next);
+        return next;
+      });
+    },
+    [applyDraft]
+  );
+
+  const save = useCallback(() => {
+    setDraft((d) => {
+      if (d) upsertCustomTheme(d);
+      return null;
+    });
+  }, []);
+
+  const cancel = useCallback(() => {
+    setDraft((d) => {
+      if (d && wasNewRef.current) removeCustomTheme(d.id);
+      const prev = prevRef.current;
+      opts.setAppearance(prev.appearance);
+      opts.setThemeId(prev.themeId);
+      apply(prev.appearance === "fixed" ? prev.themeId : "plvs-dark", listCustomThemes());
+      return null;
+    });
+  }, [opts, apply]);
+
+  return {
+    isEditing: draft != null,
+    draft,
+    beginCreate,
+    beginEdit,
+    setName,
+    updateSeed,
+    updateShell,
+    save,
+    cancel,
+  };
+}

--- a/src/hooks/useThemeEditor.js
+++ b/src/hooks/useThemeEditor.js
@@ -20,6 +20,7 @@ import {
  */
 export function useThemeEditor(opts) {
   const apply = opts.apply ?? applyThemeToDocument;
+  const notify = opts.onChange ?? (() => {});
   const [draft, setDraft] = useState(/** @type {object|null} */ (null));
   const [dirty, setDirty] = useState(false);
   const draftRef = useRef(/** @type {object|null} */ (null));
@@ -60,8 +61,9 @@ export function useThemeEditor(opts) {
       setDraftBoth(d);
       setDirty(false);
       applyDraft(d);
+      notify();
     },
-    [opts, applyDraft, setDraftBoth]
+    [opts, applyDraft, setDraftBoth, notify]
   );
 
   // Pure mutate of the current draft, then sync + apply + mark dirty (no side-effects in setState).
@@ -99,7 +101,8 @@ export function useThemeEditor(opts) {
     if (d) upsertCustomTheme(d);
     setDraftBoth(null);
     setDirty(false);
-  }, [setDraftBoth]);
+    notify();
+  }, [setDraftBoth, notify]);
 
   const cancel = useCallback(() => {
     const d = draftRef.current;
@@ -110,7 +113,8 @@ export function useThemeEditor(opts) {
     apply(prev.appearance === "fixed" ? prev.themeId : "plvs-dark", listCustomThemes());
     setDraftBoth(null);
     setDirty(false);
-  }, [opts, apply, setDraftBoth]);
+    notify();
+  }, [opts, apply, setDraftBoth, notify]);
 
   return {
     isEditing: draft != null,

--- a/src/hooks/useThemeEditor.js
+++ b/src/hooks/useThemeEditor.js
@@ -21,6 +21,8 @@ import {
 export function useThemeEditor(opts) {
   const apply = opts.apply ?? applyThemeToDocument;
   const [draft, setDraft] = useState(/** @type {object|null} */ (null));
+  const [dirty, setDirty] = useState(false);
+  const draftRef = useRef(/** @type {object|null} */ (null));
   const wasNewRef = useRef(false);
   const prevRef = useRef(opts.prevSelection);
 
@@ -29,15 +31,22 @@ export function useThemeEditor(opts) {
     [apply]
   );
 
+  // Keep state and ref in sync so save/cancel can read the latest draft without a state-updater.
+  const setDraftBoth = useCallback((next) => {
+    draftRef.current = next;
+    setDraft(next);
+  }, []);
+
   const beginEdit = useCallback(
     (theme) => {
       wasNewRef.current = false;
       prevRef.current = { appearance: "fixed", themeId: theme.id };
       const d = structuredClone(theme);
-      setDraft(d);
+      setDraftBoth(d);
+      setDirty(false);
       applyDraft(d);
     },
-    [applyDraft]
+    [applyDraft, setDraftBoth]
   );
 
   const beginCreate = useCallback(
@@ -48,64 +57,65 @@ export function useThemeEditor(opts) {
       upsertCustomTheme(d);
       opts.setAppearance("fixed");
       opts.setThemeId(d.id);
-      setDraft(d);
+      setDraftBoth(d);
+      setDirty(false);
       applyDraft(d);
     },
-    [opts, applyDraft]
+    [opts, applyDraft, setDraftBoth]
   );
 
-  const setName = useCallback((name) => {
-    setDraft((d) => (d ? { ...d, name: String(name) } : d));
-  }, []);
+  // Pure mutate of the current draft, then sync + apply + mark dirty (no side-effects in setState).
+  const edit = useCallback(
+    (mutate) => {
+      const d = draftRef.current;
+      if (!d) return;
+      const next = mutate(d);
+      setDraftBoth(next);
+      setDirty(true);
+      applyDraft(next);
+    },
+    [applyDraft, setDraftBoth]
+  );
+
+  const setName = useCallback((name) => edit((d) => ({ ...d, name: String(name) })), [edit]);
 
   const updateSeed = useCallback(
-    (key, value) => {
-      setDraft((d) => {
-        if (!d) return d;
-        const next =
-          key === "good" || key === "warn" || key === "bad"
-            ? { ...d, seeds: { ...d.seeds, signal: { ...d.seeds.signal, [key]: value } } }
-            : { ...d, seeds: { ...d.seeds, [key]: value } };
-        applyDraft(next);
-        return next;
-      });
-    },
-    [applyDraft]
+    (key, value) =>
+      edit((d) =>
+        key === "good" || key === "warn" || key === "bad"
+          ? { ...d, seeds: { ...d.seeds, signal: { ...d.seeds.signal, [key]: value } } }
+          : { ...d, seeds: { ...d.seeds, [key]: value } }
+      ),
+    [edit]
   );
 
   const updateShell = useCallback(
-    (key, value) => {
-      setDraft((d) => {
-        if (!d) return d;
-        const next = { ...d, semantic: { ...d.semantic, [key]: value } };
-        applyDraft(next);
-        return next;
-      });
-    },
-    [applyDraft]
+    (key, value) => edit((d) => ({ ...d, semantic: { ...d.semantic, [key]: value } })),
+    [edit]
   );
 
   const save = useCallback(() => {
-    setDraft((d) => {
-      if (d) upsertCustomTheme(d);
-      return null;
-    });
-  }, []);
+    const d = draftRef.current;
+    if (d) upsertCustomTheme(d);
+    setDraftBoth(null);
+    setDirty(false);
+  }, [setDraftBoth]);
 
   const cancel = useCallback(() => {
-    setDraft((d) => {
-      if (d && wasNewRef.current) removeCustomTheme(d.id);
-      const prev = prevRef.current;
-      opts.setAppearance(prev.appearance);
-      opts.setThemeId(prev.themeId);
-      apply(prev.appearance === "fixed" ? prev.themeId : "plvs-dark", listCustomThemes());
-      return null;
-    });
-  }, [opts, apply]);
+    const d = draftRef.current;
+    if (d && wasNewRef.current) removeCustomTheme(d.id);
+    const prev = prevRef.current;
+    opts.setAppearance(prev.appearance);
+    opts.setThemeId(prev.themeId);
+    apply(prev.appearance === "fixed" ? prev.themeId : "plvs-dark", listCustomThemes());
+    setDraftBoth(null);
+    setDirty(false);
+  }, [opts, apply, setDraftBoth]);
 
   return {
     isEditing: draft != null,
     draft,
+    dirty,
     beginCreate,
     beginEdit,
     setName,

--- a/src/hooks/useThemeEditor.test.js
+++ b/src/hooks/useThemeEditor.test.js
@@ -7,11 +7,11 @@ import { useThemeEditor } from "./useThemeEditor.js";
 
 beforeEach(() => themesStore.reset());
 
-function setup(apply) {
+function setup(apply, onChange = vi.fn()) {
   const selection = { appearance: "fixed", themeId: "plvs-dark" };
   const setThemeId = vi.fn((id) => (selection.themeId = id));
   const setAppearance = vi.fn((a) => (selection.appearance = a));
-  return renderHook(() =>
+  const rendered = renderHook(() =>
     useThemeEditor({
       activeTheme: BUILTIN_THEMES["plvs-dark"],
       customThemes: listCustomThemes(),
@@ -19,9 +19,11 @@ function setup(apply) {
       setThemeId,
       setAppearance,
       apply,
+      onChange,
       makeId: () => "custom-1",
     })
   );
+  return Object.assign(rendered, { onChange });
 }
 
 describe("useThemeEditor", () => {
@@ -57,6 +59,21 @@ describe("useThemeEditor", () => {
     act(() => result.current.save());
     expect(result.current.isEditing).toBe(false);
     expect(listCustomThemes()["custom-1"].seeds.accent).toBe("#22d3ee");
+  });
+
+  it("notifies onChange after store mutations so consumers can refresh listings", () => {
+    const onChange = vi.fn();
+    const { result } = setup(vi.fn(), onChange);
+    act(() => result.current.beginCreate("S"));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    act(() => result.current.save());
+    expect(onChange).toHaveBeenCalledTimes(2);
+
+    const onChange2 = vi.fn();
+    const { result: r2 } = setup(vi.fn(), onChange2);
+    act(() => r2.current.beginCreate("S2"));
+    act(() => r2.current.cancel());
+    expect(onChange2).toHaveBeenCalledTimes(2); // create + cancel(remove)
   });
 
   it("cancel of a newly-created theme removes it and restores previous selection", () => {

--- a/src/hooks/useThemeEditor.test.js
+++ b/src/hooks/useThemeEditor.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { themesStore } from "../persistence/index.js";
+import { BUILTIN_THEMES } from "../theme/builtinThemes.js";
+import { listCustomThemes } from "../theme/customThemesRepo.js";
+import { useThemeEditor } from "./useThemeEditor.js";
+
+beforeEach(() => themesStore.reset());
+
+function setup(apply) {
+  const selection = { appearance: "fixed", themeId: "plvs-dark" };
+  const setThemeId = vi.fn((id) => (selection.themeId = id));
+  const setAppearance = vi.fn((a) => (selection.appearance = a));
+  return renderHook(() =>
+    useThemeEditor({
+      activeTheme: BUILTIN_THEMES["plvs-dark"],
+      customThemes: listCustomThemes(),
+      prevSelection: { appearance: "fixed", themeId: "plvs-dark" },
+      setThemeId,
+      setAppearance,
+      apply,
+      makeId: () => "custom-1",
+    })
+  );
+}
+
+describe("useThemeEditor", () => {
+  it("beginCreate duplicates the active theme, persists, selects, and applies the draft", () => {
+    const apply = vi.fn();
+    const { result } = setup(apply);
+    act(() => result.current.beginCreate("Sunset"));
+    expect(result.current.isEditing).toBe(true);
+    expect(result.current.draft.name).toBe("Sunset");
+    expect(listCustomThemes()["custom-1"]).toBeTruthy();
+    // applied with the draft overlaid into the map
+    const [id, map] = apply.mock.calls.at(-1);
+    expect(id).toBe("custom-1");
+    expect(map["custom-1"].name).toBe("Sunset");
+  });
+
+  it("updateSeed/updateShell mutate the draft and re-apply", () => {
+    const apply = vi.fn();
+    const { result } = setup(apply);
+    act(() => result.current.beginCreate("S"));
+    act(() => result.current.updateSeed("accent", "#22d3ee"));
+    expect(result.current.draft.seeds.accent).toBe("#22d3ee");
+    act(() => result.current.updateShell("background", "#101010"));
+    expect(result.current.draft.semantic.background).toBe("#101010");
+    expect(apply.mock.calls.at(-1)[1]["custom-1"].semantic.background).toBe("#101010");
+  });
+
+  it("save persists the final draft and ends editing", () => {
+    const apply = vi.fn();
+    const { result } = setup(apply);
+    act(() => result.current.beginCreate("S"));
+    act(() => result.current.updateSeed("accent", "#22d3ee"));
+    act(() => result.current.save());
+    expect(result.current.isEditing).toBe(false);
+    expect(listCustomThemes()["custom-1"].seeds.accent).toBe("#22d3ee");
+  });
+
+  it("cancel of a newly-created theme removes it and restores previous selection", () => {
+    const apply = vi.fn();
+    const { result } = setup(apply);
+    act(() => result.current.beginCreate("S"));
+    act(() => result.current.cancel());
+    expect(result.current.isEditing).toBe(false);
+    expect(listCustomThemes()["custom-1"]).toBeUndefined();
+    // re-applied the previous theme without the draft overlay
+    expect(apply.mock.calls.at(-1)[0]).toBe("plvs-dark");
+  });
+});

--- a/src/lib/dragClamp.js
+++ b/src/lib/dragClamp.js
@@ -1,0 +1,12 @@
+/**
+ * @param {{x:number,y:number}} pos
+ * @param {{w:number,h:number}} panel
+ * @param {{w:number,h:number}} win
+ * @returns {{x:number,y:number}}
+ */
+export function clampPanelPos(pos, panel, win) {
+  return {
+    x: Math.max(0, Math.min(pos.x, win.w - panel.w)),
+    y: Math.max(0, Math.min(pos.y, win.h - panel.h)),
+  };
+}

--- a/src/lib/dragClamp.test.js
+++ b/src/lib/dragClamp.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { clampPanelPos } from "./dragClamp.js";
+
+describe("clampPanelPos", () => {
+  const win = { w: 1000, h: 800 };
+  const panel = { w: 320, h: 400 };
+  it("keeps a fully-inside position unchanged", () => {
+    expect(clampPanelPos({ x: 100, y: 100 }, panel, win)).toEqual({ x: 100, y: 100 });
+  });
+  it("clamps past the right/bottom edges", () => {
+    expect(clampPanelPos({ x: 900, y: 700 }, panel, win)).toEqual({ x: 680, y: 400 });
+  });
+  it("clamps negative to zero", () => {
+    expect(clampPanelPos({ x: -50, y: -10 }, panel, win)).toEqual({ x: 0, y: 0 });
+  });
+});

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -10,12 +10,14 @@ import {
   readSystemPrefersDark,
   resolveThemeId,
 } from "./uiPreferences";
+import { listCustomThemes } from "./theme/customThemesRepo.js";
 
 const systemPrefersDark = readSystemPrefersDark();
 const shell = readPersistedShellThemeFields(UI_PREFERENCES);
-const resolvedThemeId = resolveThemeId(shell, systemPrefersDark);
+const customThemes = listCustomThemes();
+const resolvedThemeId = resolveThemeId(shell, systemPrefersDark, customThemes);
 applyLayoutToDocument(UI_PREFERENCES);
-applyThemeToDocument(resolvedThemeId);
+applyThemeToDocument(resolvedThemeId, customThemes);
 
 createRoot(document.getElementById("root")).render(
   <React.StrictMode>

--- a/src/persistence/index.js
+++ b/src/persistence/index.js
@@ -26,6 +26,7 @@ export const workspaceStore = createDomainStore({
   migrate: migrateWorkspace,
 });
 export const presetsStore = createDomainStore({ name: "plvs:presets", backend });
+export const themesStore = createDomainStore({ name: "plvs:themes", backend });
 
 /** Whole-app snapshot of every persisted domain (foundation for problem #5). */
 export function exportAll() {
@@ -33,6 +34,7 @@ export function exportAll() {
     settings: settingsStore.export(),
     workspace: workspaceStore.export(),
     presets: presetsStore.export(),
+    themes: themesStore.export(),
   };
 }
 
@@ -41,4 +43,5 @@ export function resetAll() {
   settingsStore.reset();
   workspaceStore.reset();
   presetsStore.reset();
+  themesStore.reset();
 }

--- a/src/persistence/index.test.js
+++ b/src/persistence/index.test.js
@@ -1,6 +1,13 @@
 // src/persistence/index.test.js
 import { afterEach, describe, expect, it } from "vitest";
-import { settingsStore, workspaceStore, presetsStore, exportAll, resetAll } from "./index.js";
+import {
+  settingsStore,
+  workspaceStore,
+  presetsStore,
+  themesStore,
+  exportAll,
+  resetAll,
+} from "./index.js";
 
 describe("persistence index", () => {
   afterEach(() => {
@@ -27,6 +34,14 @@ describe("persistence index", () => {
     });
   });
 
+  it("themesStore persists under plvs:themes", () => {
+    themesStore.patch({ themes: {}, order: [] });
+    expect(JSON.parse(localStorage.getItem("plvs:themes"))).toEqual({
+      themes: {},
+      order: [],
+    });
+  });
+
   it("workspaceStore strips old preset fields", () => {
     localStorage.setItem(
       "plvs:workspace",
@@ -43,10 +58,12 @@ describe("persistence index", () => {
     settingsStore.patch({ referenceLufs: -23 });
     workspaceStore.patch({ visibleModules: ["peak"] });
     presetsStore.patch({ list: [], activeId: null });
+    themesStore.patch({ themes: {}, order: [] });
     expect(exportAll()).toEqual({
       settings: { referenceLufs: -23 },
       workspace: { visibleModules: ["peak"] },
       presets: { list: [], activeId: null },
+      themes: { themes: {}, order: [] },
     });
   });
 
@@ -54,9 +71,11 @@ describe("persistence index", () => {
     settingsStore.patch({ referenceLufs: -23 });
     workspaceStore.patch({ visibleModules: ["peak"] });
     presetsStore.patch({ list: [], activeId: null });
+    themesStore.patch({ themes: {}, order: [] });
     resetAll();
     expect(localStorage.getItem("plvs:settings")).toBeNull();
     expect(localStorage.getItem("plvs:workspace")).toBeNull();
     expect(localStorage.getItem("plvs:presets")).toBeNull();
+    expect(localStorage.getItem("plvs:themes")).toBeNull();
   });
 });

--- a/src/preferences/applyDocumentTheme.js
+++ b/src/preferences/applyDocumentTheme.js
@@ -1,6 +1,6 @@
 import { applyShadcnSemanticTokensToDocument, oklchSafe } from "../theme/shadcnSemanticPreset.js";
 import { buildThemeTokens } from "../theme/buildThemeTokens.js";
-import { getBuiltinTheme } from "../theme/builtinThemes.js";
+import { getTheme } from "../theme/themeRegistry.js";
 import { UI_PREFERENCES } from "./data.js";
 
 function setCssVar(name, value) {
@@ -105,9 +105,9 @@ export function applyLayoutToDocument(prefs = UI_PREFERENCES) {
  * Theme-owned palette tokens (ADR 0002 `applyTheme`).
  * @param {import("../theme/builtinThemes.js").ThemeId} themeId
  */
-export function applyThemeToDocument(themeId) {
+export function applyThemeToDocument(themeId, customThemes = {}) {
   if (typeof document === "undefined") return;
-  const theme = getBuiltinTheme(themeId);
+  const theme = getTheme(themeId, customThemes);
   document.documentElement.dataset.theme = theme.id;
   document.documentElement.style.setProperty("color-scheme", theme.colorScheme);
 

--- a/src/preferences/themeResolve.js
+++ b/src/preferences/themeResolve.js
@@ -4,6 +4,7 @@
  */
 
 import { DEFAULT_THEME_ID, isThemeId, THEME_IDS } from "../theme/builtinThemes.js";
+import { isKnownThemeId } from "../theme/themeRegistry.js";
 import { settingsStore } from "../persistence/index.js";
 
 export { DEFAULT_THEME_ID, isThemeId, THEME_IDS };
@@ -47,14 +48,14 @@ export function readPersistedShellThemeFields() {
  * @param {boolean} systemPrefersDark
  * @returns {import("../theme/builtinThemes.js").ThemeId}
  */
-export function resolveThemeId(shell, systemPrefersDark) {
+export function resolveThemeId(shell, systemPrefersDark, customThemes = {}) {
   const appearance = shell?.appearance === "fixed" ? "fixed" : "system";
   if (appearance === "system") {
     return systemPrefersDark ? DEFAULT_THEME_ID : "plvs-light";
   }
   const rawId = shell?.themeId;
   const id = rawId == null || rawId === "" ? null : String(rawId);
-  if (!isThemeId(id)) {
+  if (!isKnownThemeId(id, customThemes)) {
     if (import.meta.env.DEV && id != null && id !== "") {
       console.warn(`[PLVS] Unknown themeId "${id}"; falling back to ${DEFAULT_THEME_ID}.`);
     }

--- a/src/preferences/themeResolve.test.js
+++ b/src/preferences/themeResolve.test.js
@@ -5,6 +5,8 @@ import {
   resolveThemeId,
   THEME_IDS,
 } from "./themeResolve.js";
+import { makeCustomThemeFromBase } from "../theme/customTheme.js";
+import { BUILTIN_THEMES } from "../theme/builtinThemes.js";
 
 describe("resolveThemeId", () => {
   it("resolves to plvs-dark for system dark preference", () => {
@@ -92,6 +94,22 @@ describe("THEME_IDS", () => {
     expect(THEME_IDS).not.toContain("plvs-tungsten");
     expect(THEME_IDS).not.toContain("plvs-abyss");
     expect(THEME_IDS).toHaveLength(2);
+  });
+});
+
+describe("resolveThemeId with custom themes", () => {
+  const custom = makeCustomThemeFromBase(BUILTIN_THEMES["plvs-dark"], "C", () => "custom-1");
+  const customs = { "custom-1": custom };
+
+  it("resolves an existing fixed custom id to itself", () => {
+    expect(resolveThemeId({ appearance: "fixed", themeId: "custom-1" }, true, customs)).toBe(
+      "custom-1"
+    );
+  });
+  it("falls back to plvs-dark for a deleted custom id", () => {
+    expect(resolveThemeId({ appearance: "fixed", themeId: "custom-1" }, true, {})).toBe(
+      DEFAULT_THEME_ID
+    );
   });
 });
 

--- a/src/theme/buildThemeTokens.js
+++ b/src/theme/buildThemeTokens.js
@@ -43,6 +43,7 @@ export function buildThemeTokens(theme) {
     "--ui-waveform-trace": accent,
     "--ui-signal-peak-sample": accent,
     "--ui-signal-tp-max": signal.bad,
+    "--ui-signal-bad": signal.bad,
     "--ui-meter-gradient-top": signal.bad,
     "--ui-meter-gradient-mid": signal.warn,
     "--ui-meter-gradient-bottom": signal.good,

--- a/src/theme/buildThemeTokens.js
+++ b/src/theme/buildThemeTokens.js
@@ -25,6 +25,10 @@ export function buildThemeTokens(theme) {
   const gridPct = scheme === "light" ? 20 : 10;
 
   return {
+    // accent is the brand bridge into the shadcn shell (spec §3): --primary/--ring follow accent,
+    // overriding the explicit semantic values so brand buttons + focus rings track the theme accent.
+    "--primary": accent,
+    "--ring": accent,
     "--ui-loudness-momentary": accent,
     "--ui-loudness-momentary-snap": accentSnap,
     "--ui-loudness-momentary-over": over(accent),

--- a/src/theme/buildThemeTokens.js
+++ b/src/theme/buildThemeTokens.js
@@ -41,6 +41,7 @@ export function buildThemeTokens(theme) {
     "--ui-spectrum-secondary": accentSecondary,
     "--ui-spectrum-secondary-snap": snap(accentSecondary),
     "--ui-waveform-trace": accent,
+    "--ui-waveform-trace-snap": accentSnap,
     "--ui-signal-peak-sample": accent,
     "--ui-signal-tp-max": signal.bad,
     "--ui-signal-bad": signal.bad,

--- a/src/theme/buildThemeTokens.js
+++ b/src/theme/buildThemeTokens.js
@@ -44,6 +44,7 @@ export function buildThemeTokens(theme) {
     "--ui-signal-peak-sample": accent,
     "--ui-signal-tp-max": signal.bad,
     "--ui-signal-bad": signal.bad,
+    "--ui-signal-warn": signal.warn,
     "--ui-meter-gradient-top": signal.bad,
     "--ui-meter-gradient-mid": signal.warn,
     "--ui-meter-gradient-bottom": signal.good,

--- a/src/theme/buildThemeTokens.test.js
+++ b/src/theme/buildThemeTokens.test.js
@@ -43,6 +43,7 @@ describe("buildThemeTokens", () => {
       "--ui-waveform-trace",
       "--ui-signal-peak-sample",
       "--ui-signal-tp-max",
+      "--ui-signal-bad",
       "--ui-meter-gradient-top",
       "--ui-meter-gradient-mid",
       "--ui-meter-gradient-bottom",
@@ -76,5 +77,6 @@ describe("buildThemeTokens", () => {
     expect(t["--ui-meter-gradient-mid"]).toBe(signal.warn);
     expect(t["--ui-meter-gradient-top"]).toBe(signal.bad);
     expect(t["--ui-signal-tp-max"]).toBe(signal.bad);
+    expect(t["--ui-signal-bad"]).toBe(signal.bad);
   });
 });

--- a/src/theme/buildThemeTokens.test.js
+++ b/src/theme/buildThemeTokens.test.js
@@ -41,6 +41,7 @@ describe("buildThemeTokens", () => {
       "--ui-spectrum-secondary",
       "--ui-spectrum-secondary-snap",
       "--ui-waveform-trace",
+      "--ui-waveform-trace-snap",
       "--ui-signal-peak-sample",
       "--ui-signal-tp-max",
       "--ui-signal-bad",
@@ -69,6 +70,7 @@ describe("buildThemeTokens", () => {
     expect(t["--ui-vectorscope-trace-snap"]).toBe(t["--ui-loudness-momentary-snap"]);
     expect(t["--ui-spectrum-primary-snap"]).toBe(t["--ui-loudness-momentary-snap"]);
     expect(t["--ui-loudness-selection"]).toBe(t["--ui-loudness-momentary-snap"]);
+    expect(t["--ui-waveform-trace-snap"]).toBe(t["--ui-loudness-momentary-snap"]);
   });
 
   it("maps signal seed straight onto meter and tp-max", () => {

--- a/src/theme/buildThemeTokens.test.js
+++ b/src/theme/buildThemeTokens.test.js
@@ -83,4 +83,11 @@ describe("buildThemeTokens", () => {
     expect(t["--ui-signal-bad"]).toBe(signal.bad);
     expect(t["--ui-signal-warn"]).toBe(signal.warn);
   });
+
+  it("bridges accent onto the shell brand tokens --primary and --ring", () => {
+    const t = buildThemeTokens(BUILTIN_THEMES["plvs-dark"]);
+    const { accent } = BUILTIN_THEMES["plvs-dark"].seeds;
+    expect(t["--primary"]).toBe(accent);
+    expect(t["--ring"]).toBe(accent);
+  });
 });

--- a/src/theme/buildThemeTokens.test.js
+++ b/src/theme/buildThemeTokens.test.js
@@ -44,6 +44,7 @@ describe("buildThemeTokens", () => {
       "--ui-signal-peak-sample",
       "--ui-signal-tp-max",
       "--ui-signal-bad",
+      "--ui-signal-warn",
       "--ui-meter-gradient-top",
       "--ui-meter-gradient-mid",
       "--ui-meter-gradient-bottom",
@@ -78,5 +79,6 @@ describe("buildThemeTokens", () => {
     expect(t["--ui-meter-gradient-top"]).toBe(signal.bad);
     expect(t["--ui-signal-tp-max"]).toBe(signal.bad);
     expect(t["--ui-signal-bad"]).toBe(signal.bad);
+    expect(t["--ui-signal-warn"]).toBe(signal.warn);
   });
 });

--- a/src/theme/colorIO.js
+++ b/src/theme/colorIO.js
@@ -1,0 +1,37 @@
+import { oklchToHex } from "./shadcnSemanticPreset.js"; // string oklch(...) -> hex/rgba
+
+function clamp01(n) {
+  return Math.max(0, Math.min(1, n));
+}
+
+/** @param {string} value @returns {{hex:string, alpha:number}} */
+export function toEditable(value) {
+  const v = typeof value === "string" ? value.trim() : "";
+  // hex #rrggbb
+  let m = /^#([0-9a-f]{6})$/i.exec(v);
+  if (m) return { hex: `#${m[1].toLowerCase()}`, alpha: 1 };
+  // rgb/rgba
+  m = /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+)\s*)?\)$/i.exec(v);
+  if (m) {
+    const hx = (n) => Number(n).toString(16).padStart(2, "0");
+    return {
+      hex: `#${hx(m[1])}${hx(m[2])}${hx(m[3])}`,
+      alpha: m[4] == null ? 1 : clamp01(parseFloat(m[4])),
+    };
+  }
+  // oklch(...) — reuse the existing string parser, which returns hex or rgba(...)
+  if (v.startsWith("oklch(")) {
+    const out = oklchToHex(v);
+    if (out.startsWith("#")) return { hex: out, alpha: 1 };
+    return toEditable(out); // oklchToHex returned rgba(...) for the alpha case
+  }
+  return { hex: "#808080", alpha: 1 };
+}
+
+/** @param {string} hex @param {number} alpha @returns {string} */
+export function fromEditable(hex, alpha) {
+  if (alpha >= 0.999) return hex;
+  const n = parseInt(hex.slice(1), 16);
+  const a = Math.round(clamp01(alpha) * 1000) / 1000;
+  return `rgba(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255}, ${a})`;
+}

--- a/src/theme/colorIO.test.js
+++ b/src/theme/colorIO.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { toEditable, fromEditable } from "./colorIO.js";
+
+describe("colorIO", () => {
+  it("parses hex", () => {
+    expect(toEditable("#fb923c")).toEqual({ hex: "#fb923c", alpha: 1 });
+  });
+  it("parses rgba", () => {
+    expect(toEditable("rgba(255,255,255,0.04)")).toEqual({ hex: "#ffffff", alpha: 0.04 });
+  });
+  it("parses oklch (incl alpha)", () => {
+    const e = toEditable("oklch(1 0 0 / 9%)");
+    expect(e.hex.toLowerCase()).toBe("#ffffff");
+    expect(e.alpha).toBeCloseTo(0.09, 2);
+  });
+  it("round-trips: opaque -> hex, translucent -> rgba", () => {
+    expect(fromEditable("#fb923c", 1)).toBe("#fb923c");
+    expect(fromEditable("#ffffff", 0.04)).toBe("rgba(255, 255, 255, 0.04)");
+  });
+  it("falls back to a safe default for unparseable input", () => {
+    expect(toEditable("nonsense").hex).toMatch(/^#[0-9a-f]{6}$/i);
+  });
+});

--- a/src/theme/customTheme.js
+++ b/src/theme/customTheme.js
@@ -1,0 +1,61 @@
+export const CUSTOM_THEME_ID_PREFIX = "custom-";
+
+/** @param {unknown} id */
+export function isCustomThemeId(id) {
+  return typeof id === "string" && id.startsWith(CUSTOM_THEME_ID_PREFIX);
+}
+
+const defaultMakeId = () => `${CUSTOM_THEME_ID_PREFIX}${crypto.randomUUID()}`;
+
+/**
+ * Snapshot a builtin or custom theme into a new editable CustomTheme.
+ * @param {{colorScheme:string, seeds:object, semantic:object, colormap:unknown}} base
+ * @param {string} name
+ * @param {() => string} [makeId]
+ */
+export function makeCustomThemeFromBase(base, name, makeId = defaultMakeId) {
+  return {
+    id: makeId(),
+    name: String(name),
+    colorScheme: base.colorScheme === "light" ? "light" : "dark",
+    seeds: {
+      accent: base.seeds.accent,
+      accentSecondary: base.seeds.accentSecondary,
+      signal: {
+        good: base.seeds.signal.good,
+        warn: base.seeds.signal.warn,
+        bad: base.seeds.signal.bad,
+      },
+    },
+    semantic: { ...base.semantic },
+    colormap: structuredClone(base.colormap),
+  };
+}
+
+function isNonEmptyString(v) {
+  return typeof v === "string" && v.length > 0;
+}
+
+/**
+ * Validate a persisted custom theme; return it (as-is) or null if malformed.
+ * @param {unknown} raw
+ */
+export function normalizeCustomTheme(raw) {
+  if (!raw || typeof raw !== "object") return null;
+  const t = /** @type {any} */ (raw);
+  if (!isCustomThemeId(t.id) || !isNonEmptyString(t.name)) return null;
+  if (t.colorScheme !== "dark" && t.colorScheme !== "light") return null;
+  const s = t.seeds;
+  if (!s || typeof s !== "object") return null;
+  if (!isNonEmptyString(s.accent) || !isNonEmptyString(s.accentSecondary)) return null;
+  if (
+    !s.signal ||
+    !isNonEmptyString(s.signal.good) ||
+    !isNonEmptyString(s.signal.warn) ||
+    !isNonEmptyString(s.signal.bad)
+  )
+    return null;
+  if (!t.semantic || typeof t.semantic !== "object") return null;
+  if (!Array.isArray(t.colormap)) return null;
+  return t;
+}

--- a/src/theme/customTheme.test.js
+++ b/src/theme/customTheme.test.js
@@ -1,10 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  CUSTOM_THEME_ID_PREFIX,
-  isCustomThemeId,
-  makeCustomThemeFromBase,
-  normalizeCustomTheme,
-} from "./customTheme.js";
+import { isCustomThemeId, makeCustomThemeFromBase, normalizeCustomTheme } from "./customTheme.js";
 import { BUILTIN_THEMES } from "./builtinThemes.js";
 
 describe("isCustomThemeId", () => {

--- a/src/theme/customTheme.test.js
+++ b/src/theme/customTheme.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import {
+  CUSTOM_THEME_ID_PREFIX,
+  isCustomThemeId,
+  makeCustomThemeFromBase,
+  normalizeCustomTheme,
+} from "./customTheme.js";
+import { BUILTIN_THEMES } from "./builtinThemes.js";
+
+describe("isCustomThemeId", () => {
+  it("is true only for the custom prefix", () => {
+    expect(isCustomThemeId("custom-abc")).toBe(true);
+    expect(isCustomThemeId("plvs-dark")).toBe(false);
+    expect(isCustomThemeId(null)).toBe(false);
+  });
+});
+
+describe("makeCustomThemeFromBase", () => {
+  it("snapshots seeds/semantic/colormap/colorScheme from the base with a new id and name", () => {
+    const base = BUILTIN_THEMES["plvs-dark"];
+    const t = makeCustomThemeFromBase(base, "Sunset", () => "custom-fixed");
+    expect(t.id).toBe("custom-fixed");
+    expect(t.name).toBe("Sunset");
+    expect(t.colorScheme).toBe("dark");
+    expect(t.seeds.accent).toBe(base.seeds.accent);
+    expect(t.seeds).not.toBe(base.seeds); // deep copy
+    expect(t.semantic).toEqual(base.semantic);
+    expect(t.semantic).not.toBe(base.semantic);
+    expect(t.colormap).toEqual(base.colormap);
+  });
+});
+
+describe("normalizeCustomTheme", () => {
+  it("returns the theme for a valid object", () => {
+    const base = BUILTIN_THEMES["plvs-light"];
+    const t = makeCustomThemeFromBase(base, "Mine", () => "custom-1");
+    expect(normalizeCustomTheme(t)).toEqual(t);
+  });
+  it("returns null for invalid input", () => {
+    expect(normalizeCustomTheme(null)).toBeNull();
+    expect(normalizeCustomTheme({ id: "plvs-dark" })).toBeNull(); // not a custom id
+    expect(normalizeCustomTheme({ id: "custom-x" })).toBeNull(); // missing fields
+  });
+});

--- a/src/theme/customThemesRepo.js
+++ b/src/theme/customThemesRepo.js
@@ -1,0 +1,55 @@
+import { themesStore } from "../persistence/index.js";
+import { normalizeCustomTheme } from "./customTheme.js";
+
+function readState() {
+  const raw = themesStore.read();
+  const themes = raw && typeof raw.themes === "object" && raw.themes ? raw.themes : {};
+  const order = Array.isArray(raw && raw.order) ? raw.order : [];
+  return { themes, order };
+}
+
+/** @returns {Record<string, object>} valid custom themes keyed by id */
+export function listCustomThemes() {
+  const { themes } = readState();
+  /** @type {Record<string, object>} */
+  const out = {};
+  for (const [id, t] of Object.entries(themes)) {
+    const n = normalizeCustomTheme(t);
+    if (n) out[id] = n;
+  }
+  return out;
+}
+
+/** @returns {object[]} valid custom themes in display order */
+export function listCustomThemesOrdered() {
+  const { order } = readState();
+  const valid = listCustomThemes();
+  const seen = new Set();
+  const ordered = [];
+  for (const id of order) {
+    if (valid[id] && !seen.has(id)) {
+      ordered.push(valid[id]);
+      seen.add(id);
+    }
+  }
+  for (const [id, t] of Object.entries(valid)) {
+    if (!seen.has(id)) ordered.push(t);
+  }
+  return ordered;
+}
+
+export function upsertCustomTheme(theme) {
+  const n = normalizeCustomTheme(theme);
+  if (!n) return;
+  const { themes, order } = readState();
+  themesStore.patch({
+    themes: { ...themes, [n.id]: n },
+    order: order.includes(n.id) ? order : [...order, n.id],
+  });
+}
+
+export function removeCustomTheme(id) {
+  const { themes, order } = readState();
+  const { [id]: _drop, ...rest } = themes;
+  themesStore.patch({ themes: rest, order: order.filter((x) => x !== id) });
+}

--- a/src/theme/customThemesRepo.test.js
+++ b/src/theme/customThemesRepo.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { themesStore } from "../persistence/index.js";
+import { makeCustomThemeFromBase } from "./customTheme.js";
+import { BUILTIN_THEMES } from "./builtinThemes.js";
+import {
+  listCustomThemes,
+  listCustomThemesOrdered,
+  upsertCustomTheme,
+  removeCustomTheme,
+} from "./customThemesRepo.js";
+
+function mk(id, name = "T") {
+  return makeCustomThemeFromBase(BUILTIN_THEMES["plvs-dark"], name, () => id);
+}
+
+beforeEach(() => themesStore.reset());
+
+describe("customThemesRepo", () => {
+  it("upserts and lists themes", () => {
+    upsertCustomTheme(mk("custom-a", "A"));
+    upsertCustomTheme(mk("custom-b", "B"));
+    expect(Object.keys(listCustomThemes())).toEqual(["custom-a", "custom-b"]);
+    expect(listCustomThemesOrdered().map((t) => t.id)).toEqual(["custom-a", "custom-b"]);
+  });
+  it("updates in place without reordering", () => {
+    upsertCustomTheme(mk("custom-a", "A"));
+    upsertCustomTheme(mk("custom-b", "B"));
+    upsertCustomTheme(mk("custom-a", "A2"));
+    expect(listCustomThemesOrdered().map((t) => t.name)).toEqual(["A2", "B"]);
+  });
+  it("removes a theme from map and order", () => {
+    upsertCustomTheme(mk("custom-a"));
+    upsertCustomTheme(mk("custom-b"));
+    removeCustomTheme("custom-a");
+    expect(listCustomThemesOrdered().map((t) => t.id)).toEqual(["custom-b"]);
+  });
+  it("drops malformed persisted entries from listings", () => {
+    themesStore.patch({ themes: { "custom-x": { id: "custom-x" } }, order: ["custom-x"] });
+    expect(listCustomThemes()).toEqual({});
+  });
+});

--- a/src/theme/themeRegistry.js
+++ b/src/theme/themeRegistry.js
@@ -1,0 +1,23 @@
+import { BUILTIN_THEMES, DEFAULT_THEME_ID } from "./builtinThemes.js";
+
+/**
+ * @param {unknown} id
+ * @param {Record<string, object>} [customThemes]
+ */
+export function isKnownThemeId(id, customThemes = {}) {
+  if (typeof id !== "string") return false;
+  return id in BUILTIN_THEMES || id in customThemes;
+}
+
+/**
+ * @param {unknown} id
+ * @param {Record<string, object>} [customThemes]
+ * @returns {object} a builtin or custom theme; falls back to plvs-dark
+ */
+export function getTheme(id, customThemes = {}) {
+  if (typeof id === "string") {
+    if (id in BUILTIN_THEMES) return BUILTIN_THEMES[id];
+    if (id in customThemes) return customThemes[id];
+  }
+  return BUILTIN_THEMES[DEFAULT_THEME_ID];
+}

--- a/src/theme/themeRegistry.test.js
+++ b/src/theme/themeRegistry.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { BUILTIN_THEMES } from "./builtinThemes.js";
+import { makeCustomThemeFromBase } from "./customTheme.js";
+import { getTheme, isKnownThemeId } from "./themeRegistry.js";
+
+const custom = makeCustomThemeFromBase(BUILTIN_THEMES["plvs-dark"], "C", () => "custom-1");
+const customs = { "custom-1": custom };
+
+describe("themeRegistry", () => {
+  it("resolves builtins and customs", () => {
+    expect(getTheme("plvs-light", customs)).toBe(BUILTIN_THEMES["plvs-light"]);
+    expect(getTheme("custom-1", customs)).toBe(custom);
+  });
+  it("falls back to plvs-dark for unknown", () => {
+    expect(getTheme("nope", customs)).toBe(BUILTIN_THEMES["plvs-dark"]);
+    expect(getTheme("custom-1", {})).toBe(BUILTIN_THEMES["plvs-dark"]);
+  });
+  it("isKnownThemeId reflects builtins and customs", () => {
+    expect(isKnownThemeId("plvs-dark", customs)).toBe(true);
+    expect(isKnownThemeId("custom-1", customs)).toBe(true);
+    expect(isKnownThemeId("custom-1", {})).toBe(false);
+    expect(isKnownThemeId("nope", customs)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add persisted custom themes and theme registry integration across Settings, document theme application, and spectrogram rendering.
- Add a floating custom theme editor with color controls, discard confirmation, and guarded Settings theme controls while editing.
- Polish Settings custom theme actions and defaults, including Add New Theme layout and Custom default names.

## Test plan
- npm run check