### PR TITLE
fix: stabilize shortcut capture and Dock accessories

### DIFF
--- a/src-tauri/src/dock_accessories.rs
+++ b/src-tauri/src/dock_accessories.rs
@@ -125,6 +125,61 @@ pub fn hide_all<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
   }
 }
 
+fn point_inside(bounds: WindowBounds, x: f64, y: f64) -> bool {
+  x >= bounds.x as f64
+    && x < (bounds.x as f64 + bounds.width as f64)
+    && y >= bounds.y as f64
+    && y < (bounds.y as f64 + bounds.height as f64)
+}
+
+fn visible_window_contains<R: tauri::Runtime>(
+  window: &WebviewWindow<R>,
+  x: f64,
+  y: f64,
+) -> Result<bool, String> {
+  if !window
+    .is_visible()
+    .map_err(|e| format!("{} visibility: {e}", window.label()))?
+  {
+    return Ok(false);
+  }
+  let position = window
+    .outer_position()
+    .map_err(|e| format!("{} position: {e}", window.label()))?;
+  let size = window
+    .inner_size()
+    .map_err(|e| format!("{} size: {e}", window.label()))?;
+  Ok(point_inside(
+    WindowBounds {
+      x: position.x,
+      y: position.y,
+      width: size.width,
+      height: size.height,
+      is_maximized: false,
+    },
+    x,
+    y,
+  ))
+}
+
+#[tauri::command]
+pub fn cursor_over_dock_surfaces<R: tauri::Runtime>(
+  window: WebviewWindow<R>,
+) -> Result<bool, String> {
+  let app = window.app_handle();
+  let cursor = app
+    .cursor_position()
+    .map_err(|e| format!("dock cursor position: {e}"))?;
+  for label in ["main", DOCK_HEADER_LABEL, DOCK_EDITOR_LABEL] {
+    if let Some(surface) = app.get_webview_window(label) {
+      if visible_window_contains(&surface, cursor.x, cursor.y)? {
+        return Ok(true);
+      }
+    }
+  }
+  Ok(false)
+}
+
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
 pub fn set_dock_accessories<R: tauri::Runtime>(
@@ -174,4 +229,28 @@ pub fn set_dock_accessories<R: tauri::Runtime>(
     show_or_hide(&editor, editor_visible, true)?;
   }
   Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn bounds(x: i32, y: i32, width: u32, height: u32) -> WindowBounds {
+    WindowBounds {
+      x,
+      y,
+      width,
+      height,
+      is_maximized: false,
+    }
+  }
+
+  #[test]
+  fn point_inside_uses_physical_half_open_window_bounds() {
+    let rect = bounds(-1280, 900, 1280, 72);
+    assert!(point_inside(rect, -1280.0, 900.0));
+    assert!(point_inside(rect, -0.1, 971.9));
+    assert!(!point_inside(rect, 0.0, 930.0));
+    assert!(!point_inside(rect, -640.0, 972.0));
+  }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -88,6 +88,7 @@ pub fn run() {
       dock::set_dock_suspended,
       dock::set_dock_height,
       dock_accessories::set_dock_accessories,
+      dock_accessories::cursor_over_dock_surfaces,
       glass_effect::set_glass_effect,
     ])
     .setup(|app| {

--- a/src/components/ShortcutCapture.jsx
+++ b/src/components/ShortcutCapture.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { keyEventToAccelerator, formatAcceleratorForDisplay } from "@/lib/accelerator.js";
 import { reservedComboConflict } from "@/data/keyboardShortcuts.js";
@@ -12,19 +12,20 @@ export function ShortcutCapture({
 }) {
   const [recording, setRecording] = useState(false);
   const [hint, setHint] = useState("");
+  const buttonRef = useRef(null);
 
-  const stopRecording = (el) => {
+  const stopRecording = () => {
     setRecording(false);
     setHint("");
     onRecordingChange(false);
-    el?.blur();
+    buttonRef.current?.blur();
   };
 
   const onKeyDown = (e) => {
     e.preventDefault();
     e.stopPropagation();
     if (e.key === "Escape") {
-      stopRecording(e.currentTarget);
+      stopRecording();
       return;
     }
     const accel = keyEventToAccelerator(e);
@@ -38,12 +39,22 @@ export function ShortcutCapture({
       return;
     }
     onChange(accel);
-    stopRecording(e.currentTarget);
+    stopRecording();
   };
+
+  useEffect(() => {
+    if (!recording) return;
+    // WebViews disagree about whether a clicked button owns keyboard focus.
+    // Capture at the window only while the recorder is active, then remove the
+    // listener immediately so normal application shortcuts are unaffected.
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [recording, onKeyDown]);
 
   return (
     <div className="flex flex-col items-end gap-0.5">
       <Button
+        ref={buttonRef}
         type="button"
         variant="outline"
         size="sm"
@@ -55,8 +66,7 @@ export function ShortcutCapture({
           setHint("");
           onRecordingChange(true);
         }}
-        onKeyDown={recording ? onKeyDown : undefined}
-        onBlur={(e) => stopRecording(e.currentTarget)}
+        onBlur={stopRecording}
       >
         {recording ? "Press a combo…" : formatAcceleratorForDisplay(value, { isMac })}
       </Button>

--- a/src/components/ShortcutCapture.test.jsx
+++ b/src/components/ShortcutCapture.test.jsx
@@ -18,6 +18,32 @@ describe("ShortcutCapture", () => {
     expect(onChange).toHaveBeenCalledWith("CmdOrCtrl+Alt+J");
   });
 
+  it("captures from the window on macOS when WKWebView leaves focus on the dialog", () => {
+    const onChange = vi.fn();
+    render(<ShortcutCapture value="CmdOrCtrl+K" onChange={onChange} isMac={true} />);
+    const btn = screen.getByLabelText("Clear shortcut");
+
+    fireEvent.click(btn);
+    fireEvent.keyDown(window, { key: "j", metaKey: true });
+
+    expect(onChange).toHaveBeenCalledWith("CmdOrCtrl+J");
+    expect(btn.textContent).toBe("⌘K");
+  });
+
+  it("uses the same window capture path on Windows", () => {
+    const onChange = vi.fn();
+    render(<ShortcutCapture value="CmdOrCtrl+K" onChange={onChange} isMac={false} />);
+    const btn = screen.getByLabelText("Clear shortcut");
+
+    fireEvent.click(btn);
+    fireEvent.keyDown(window, { key: "j", ctrlKey: true });
+    expect(onChange).toHaveBeenCalledWith("CmdOrCtrl+J");
+    expect(btn.textContent).toBe("Ctrl+K");
+
+    fireEvent.keyDown(window, { key: "m", ctrlKey: true });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects a combo with no modifier and shows a hint", () => {
     const onChange = vi.fn();
     render(<ShortcutCapture value="CmdOrCtrl+Alt+K" onChange={onChange} isMac={false} />);

--- a/src/dock/accessories/DockEditorApp.jsx
+++ b/src/dock/accessories/DockEditorApp.jsx
@@ -85,26 +85,30 @@ export function DockEditorApp() {
     const root = rootRef.current;
     if (!root) return;
     let frame = 0;
-    const measure = () => {
-      cancelAnimationFrame(frame);
-      frame = requestAnimationFrame(() => {
-        const next = measureDockEditorContent(root);
-        if (!next) return;
-        if (
-          lastSizeRef.current?.width === next.width &&
-          lastSizeRef.current?.height === next.height
-        ) {
-          return;
-        }
-        lastSizeRef.current = next;
-        action("resize-editor", { ...next, view: payload.view });
-      });
+    const measureNow = () => {
+      const next = measureDockEditorContent(root);
+      if (!next) return;
+      if (
+        lastSizeRef.current?.view === payload.view &&
+        lastSizeRef.current?.width === next.width &&
+        lastSizeRef.current?.height === next.height
+      ) {
+        return;
+      }
+      lastSizeRef.current = { ...next, view: payload.view };
+      action("resize-editor", { ...next, view: payload.view });
     };
-    measure();
+    const scheduleMeasure = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(measureNow);
+    };
+    // Hidden WKWebViews may not receive an animation frame. Measure once from
+    // the committed DOM so the native window can be sized before it is shown.
+    measureNow();
     const resizeObserver =
-      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(measure);
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(scheduleMeasure);
     resizeObserver?.observe(root);
-    const mutationObserver = new MutationObserver(measure);
+    const mutationObserver = new MutationObserver(scheduleMeasure);
     mutationObserver.observe(root, { childList: true, subtree: true, characterData: true });
     return () => {
       cancelAnimationFrame(frame);

--- a/src/dock/accessories/DockEditorApp.test.jsx
+++ b/src/dock/accessories/DockEditorApp.test.jsx
@@ -130,6 +130,31 @@ describe("DockEditorApp window behavior", () => {
     );
   });
 
+  it("publishes the initial size even when a hidden webview receives no animation frame", () => {
+    const animationFrame = vi.spyOn(window, "requestAnimationFrame").mockReturnValue(1);
+
+    render(<DockEditorApp />);
+
+    expect(action).toHaveBeenCalledWith(
+      "resize-editor",
+      expect.objectContaining({ view: "presets" })
+    );
+    animationFrame.mockRestore();
+  });
+
+  it("publishes size for a replacement editor even when its dimensions match", () => {
+    const { rerender } = render(<DockEditorApp />);
+    action.mockClear();
+
+    client.payload = { ...PRESETS_PAYLOAD, view: "modules" };
+    rerender(<DockEditorApp />);
+
+    expect(action).toHaveBeenCalledWith(
+      "resize-editor",
+      expect.objectContaining({ view: "modules" })
+    );
+  });
+
   it("lets module settings use their intrinsic width", () => {
     client.payload = {
       ...PRESETS_PAYLOAD,

--- a/src/dock/useDockAccessoryVisibility.js
+++ b/src/dock/useDockAccessoryVisibility.js
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { setDockAccessories } from "../ipc/commands.js";
+import { cursorOverDockSurfaces, setDockAccessories } from "../ipc/commands.js";
 import { isTauri } from "../ipc/env.js";
 import { shouldShowDockHeader } from "./accessoryVisibility.js";
 
 const ACCESSORY_READY_RETRY_MS = 50;
 const ACCESSORY_READY_ATTEMPTS = 4;
+const CURSOR_RECONCILE_MS = 33;
 
 function initialEditorSize(view) {
   if (view === "presets") return { width: 240, height: 560 };
@@ -33,6 +34,34 @@ export async function setDockAccessoriesWhenReady(
   }
 }
 
+export function createLatestDockAccessoryUpdater({ command = setDockAccessoriesWhenReady } = {}) {
+  let latestRequest = 0;
+  let pending = null;
+  let running = false;
+
+  const drain = async () => {
+    running = true;
+    while (pending !== null) {
+      const current = pending;
+      pending = null;
+      try {
+        await command(current.options);
+      } catch (error) {
+        if (current.request === latestRequest) current.onError?.(error);
+      }
+    }
+    running = false;
+  };
+
+  return {
+    update(options, onError) {
+      latestRequest += 1;
+      pending = { request: latestRequest, options, onError };
+      if (!running) void drain();
+    },
+  };
+}
+
 export function useDockAccessoryVisibility({
   active,
   edge,
@@ -48,10 +77,14 @@ export function useDockAccessoryVisibility({
   const [measuredEditorView, setMeasuredEditorView] = useState(null);
   const editorViewRef = useRef(null);
   const measuredEditorViewRef = useRef(null);
-  const requestRef = useRef(0);
-  const commandQueueRef = useRef(Promise.resolve());
+  const presenceRevisionRef = useRef(0);
+  const accessoryUpdaterRef = useRef(null);
+  if (accessoryUpdaterRef.current === null) {
+    accessoryUpdaterRef.current = createLatestDockAccessoryUpdater();
+  }
 
   const updatePresence = useCallback((key, inside) => {
+    presenceRevisionRef.current += 1;
     setPresence((current) => ({ ...current, [key]: inside }));
     if (inside) setHeaderVisible(true);
   }, []);
@@ -94,6 +127,7 @@ export function useDockAccessoryVisibility({
   useEffect(() => {
     if (!active) {
       const resetTimer = setTimeout(() => {
+        presenceRevisionRef.current += 1;
         editorViewRef.current = null;
         measuredEditorViewRef.current = null;
         setMeasuredEditorView(null);
@@ -119,23 +153,56 @@ export function useDockAccessoryVisibility({
   }, [active, editorView, forceHeaderVisible, presence]);
 
   useEffect(() => {
+    if (!active || editorView !== null || forceHeaderVisible || !isTauri()) {
+      return;
+    }
+    let cancelled = false;
+    let timer = null;
+    const schedule = () => {
+      timer = window.setTimeout(async () => {
+        const revision = presenceRevisionRef.current;
+        try {
+          const inside = await cursorOverDockSurfaces();
+          if (!cancelled && presenceRevisionRef.current === revision) {
+            setPresence((current) => {
+              if (cancelled || presenceRevisionRef.current !== revision) return current;
+              if (inside && !current.stripInside && !current.headerInside) {
+                presenceRevisionRef.current += 1;
+                return { stripInside: true, headerInside: false };
+              }
+              if (!inside && (current.stripInside || current.headerInside)) {
+                presenceRevisionRef.current += 1;
+                return { stripInside: false, headerInside: false };
+              }
+              return current;
+            });
+          }
+        } catch (_) {
+          // DOM pointer events remain the fast path if native reconciliation is unavailable.
+        }
+        if (!cancelled) schedule();
+      }, CURSOR_RECONCILE_MS);
+    };
+    schedule();
+    return () => {
+      cancelled = true;
+      if (timer !== null) window.clearTimeout(timer);
+    };
+  }, [active, editorView, forceHeaderVisible]);
+
+  useEffect(() => {
     if (!isTauri()) return;
-    const request = ++requestRef.current;
-    commandQueueRef.current = commandQueueRef.current
-      .catch(() => {})
-      .then(() =>
-        setDockAccessoriesWhenReady({
-          edge,
-          headerVisible: active && headerVisible,
-          editorVisible: active && editorView !== null && measuredEditorView !== null,
-          editorWidth: editorSize.width,
-          editorHeight: editorSize.height,
-          editorAnchorX,
-        })
-      );
-    void commandQueueRef.current.catch((error) => {
-      if (request === requestRef.current) onError?.(error);
-    });
+    accessoryUpdaterRef.current.update(
+      {
+        edge,
+        headerVisible: active && headerVisible,
+        editorVisible: active && editorView !== null && measuredEditorView !== null,
+        editorWidth: editorSize.width,
+        editorHeight: editorSize.height,
+        editorAnchorX,
+      },
+      onError
+    );
   }, [
     active,
     edge,

--- a/src/dock/useDockAccessoryVisibility.test.jsx
+++ b/src/dock/useDockAccessoryVisibility.test.jsx
@@ -1,17 +1,24 @@
 /** @vitest-environment jsdom */
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { setDockAccessories } from "../ipc/commands.js";
+import { cursorOverDockSurfaces, setDockAccessories } from "../ipc/commands.js";
 import {
+  createLatestDockAccessoryUpdater,
   setDockAccessoriesWhenReady,
   useDockAccessoryVisibility,
 } from "./useDockAccessoryVisibility.js";
 
 vi.mock("../ipc/env.js", () => ({ isTauri: () => true }));
-vi.mock("../ipc/commands.js", () => ({ setDockAccessories: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("../ipc/commands.js", () => ({
+  cursorOverDockSurfaces: vi.fn().mockResolvedValue(true),
+  setDockAccessories: vi.fn().mockResolvedValue(undefined),
+}));
 
 describe("useDockAccessoryVisibility", () => {
-  beforeEach(() => vi.useFakeTimers());
+  beforeEach(() => {
+    vi.useFakeTimers();
+    cursorOverDockSurfaces.mockResolvedValue(true);
+  });
   afterEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
@@ -36,6 +43,94 @@ describe("useDockAccessoryVisibility", () => {
     );
   });
 
+  it("repairs a missed pointer leave from live native window geometry", async () => {
+    cursorOverDockSurfaces.mockResolvedValue(false);
+    const { result } = renderHook(() =>
+      useDockAccessoryVisibility({ active: true, edge: "bottom" })
+    );
+
+    act(() => result.current.onStripPointerEnter());
+    expect(result.current.headerVisible).toBe(true);
+    await act(async () => {
+      vi.advanceTimersByTime(33);
+      await Promise.resolve();
+    });
+    act(() => vi.advanceTimersByTime(0));
+
+    expect(result.current.headerVisible).toBe(false);
+    expect(cursorOverDockSurfaces).toHaveBeenCalledOnce();
+  });
+
+  it("repairs a missed re-enter after native geometry hid the header", async () => {
+    cursorOverDockSurfaces.mockResolvedValue(false);
+    const { result } = renderHook(() =>
+      useDockAccessoryVisibility({ active: true, edge: "bottom" })
+    );
+
+    act(() => result.current.onStripPointerEnter());
+    await act(async () => {
+      vi.advanceTimersByTime(33);
+      await Promise.resolve();
+    });
+    act(() => vi.advanceTimersByTime(0));
+    expect(result.current.headerVisible).toBe(false);
+
+    cursorOverDockSurfaces.mockResolvedValue(true);
+    await act(async () => {
+      vi.advanceTimersByTime(33);
+      await Promise.resolve();
+    });
+    act(() => vi.advanceTimersByTime(0));
+
+    expect(result.current.headerVisible).toBe(true);
+    expect(cursorOverDockSurfaces).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not fight reliable DOM enter and leave events when native geometry agrees", async () => {
+    cursorOverDockSurfaces.mockResolvedValue(true);
+    const { result } = renderHook(() =>
+      useDockAccessoryVisibility({ active: true, edge: "bottom" })
+    );
+
+    act(() => result.current.onStripPointerEnter());
+    await act(async () => {
+      vi.advanceTimersByTime(33);
+      await Promise.resolve();
+    });
+    expect(result.current.headerVisible).toBe(true);
+
+    cursorOverDockSurfaces.mockResolvedValue(false);
+    act(() => result.current.onStripPointerLeave());
+    act(() => vi.advanceTimersByTime(0));
+    expect(result.current.headerVisible).toBe(false);
+
+    await act(async () => {
+      vi.advanceTimersByTime(33);
+      await Promise.resolve();
+    });
+    act(() => vi.advanceTimersByTime(0));
+    expect(result.current.headerVisible).toBe(false);
+  });
+
+  it("does not let a stale cursor result overwrite a newer pointer enter", async () => {
+    let resolveCursor;
+    cursorOverDockSurfaces.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCursor = resolve;
+      })
+    );
+    const { result } = renderHook(() =>
+      useDockAccessoryVisibility({ active: true, edge: "bottom" })
+    );
+
+    act(() => result.current.onStripPointerEnter());
+    act(() => vi.advanceTimersByTime(33));
+    act(() => result.current.onAccessoryPointer({ surface: "dock-header", inside: true }));
+    await act(async () => resolveCursor(false));
+
+    expect(result.current.headerVisible).toBe(true);
+  });
+
   it("keeps header and editor visible until the editor closes", () => {
     const { result } = renderHook(() => useDockAccessoryVisibility({ active: true, edge: "top" }));
     act(() => result.current.openEditor("modules"));
@@ -47,6 +142,43 @@ describe("useDockAccessoryVisibility", () => {
     act(() => vi.advanceTimersByTime(0));
     expect(result.current.editorView).toBeNull();
     expect(result.current.headerVisible).toBe(false);
+  });
+
+  it("does not reconcile hover while an editor or forced error keeps the header open", () => {
+    const { result, rerender } = renderHook(
+      ({ forceHeaderVisible }) =>
+        useDockAccessoryVisibility({ active: true, edge: "top", forceHeaderVisible }),
+      { initialProps: { forceHeaderVisible: false } }
+    );
+
+    act(() => result.current.openEditor("presets"));
+    act(() => vi.advanceTimersByTime(1000));
+    expect(cursorOverDockSurfaces).not.toHaveBeenCalled();
+
+    act(() => result.current.closeEditor());
+    rerender({ forceHeaderVisible: true });
+    act(() => vi.advanceTimersByTime(1000));
+    expect(cursorOverDockSurfaces).not.toHaveBeenCalled();
+  });
+
+  it("stops reconciliation across preset-style Dock exit and restarts with live geometry", async () => {
+    const { result, rerender } = renderHook(
+      ({ active, edge }) => useDockAccessoryVisibility({ active, edge }),
+      { initialProps: { active: true, edge: "bottom" } }
+    );
+
+    act(() => result.current.onStripPointerEnter());
+    rerender({ active: true, edge: "top" });
+    await act(async () => {
+      vi.advanceTimersByTime(33);
+      await Promise.resolve();
+    });
+    expect(cursorOverDockSurfaces).toHaveBeenCalledOnce();
+
+    rerender({ active: false, edge: "top" });
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current.headerVisible).toBe(false);
+    expect(cursorOverDockSurfaces).toHaveBeenCalledOnce();
   });
 
   it("keeps the header visible while an error requires attention", async () => {
@@ -117,6 +249,32 @@ describe("useDockAccessoryVisibility", () => {
 
     expect(command).toHaveBeenCalledOnce();
     expect(wait).not.toHaveBeenCalled();
+  });
+
+  it("coalesces rapid accessory updates to the latest state", async () => {
+    let resolveFirst;
+    const command = vi
+      .fn()
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        })
+      )
+      .mockResolvedValue(undefined);
+    const updater = createLatestDockAccessoryUpdater({ command });
+
+    updater.update({ headerVisible: false });
+    updater.update({ headerVisible: true });
+    updater.update({ headerVisible: false });
+    updater.update({ headerVisible: true });
+
+    expect(command).toHaveBeenCalledOnce();
+    resolveFirst();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(command).toHaveBeenCalledTimes(2);
+    expect(command).toHaveBeenLastCalledWith({ headerVisible: true });
   });
 
   it("keeps the editor hidden until its intrinsic dimensions are measured", async () => {

--- a/src/ipc/commands.js
+++ b/src/ipc/commands.js
@@ -124,6 +124,11 @@ export function setDockAccessories({
   });
 }
 
+/** Whether the global cursor is inside any visible Dock surface window. */
+export function cursorOverDockSurfaces() {
+  return invoke("cursor_over_dock_surfaces");
+}
+
 export function exportProfileCommand() {
   return invoke("export_profile");
 }

--- a/src/ipc/commands.test.js
+++ b/src/ipc/commands.test.js
@@ -10,6 +10,7 @@ vi.mock("@tauri-apps/api/core", () => ({
 }));
 
 import {
+  cursorOverDockSurfaces,
   probeFileAnalysis,
   getDockState,
   setDialogueGating,
@@ -78,6 +79,11 @@ describe("audio engine command seam", () => {
 });
 
 describe("dock command seam", () => {
+  it("asks Rust to reconcile the cursor against live Dock window geometry", async () => {
+    await cursorOverDockSurfaces();
+    expect(invoke).toHaveBeenCalledWith("cursor_over_dock_surfaces");
+  });
+
   it("reads the native-authoritative Dock state", async () => {
     await getDockState();
     expect(invoke).toHaveBeenCalledWith("get_dock_state");


### PR DESCRIPTION
## Summary
- capture shortcut combinations at the window level while recording
- reconcile Dock accessory hover state with native window geometry
- measure hidden Dock editors before showing them

## Verification
- npm run check