### PR TITLE
deps(rust): migrate to rubato 2.0 API

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3154,7 +3154,7 @@ dependencies = [
  "firered-vad",
  "log",
  "realfft",
- "rubato 0.16.2",
+ "rubato",
  "rustfft",
  "serde",
  "serde_json",
@@ -3536,18 +3536,6 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rubato"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5258099699851cfd0082aeb645feb9c084d9a5e1f1b8d5372086b989fc5e56a1"
-dependencies = [
- "num-complex",
- "num-integer",
- "num-traits",
- "realfft",
 ]
 
 [[package]]
@@ -4736,7 +4724,7 @@ dependencies = [
  "log",
  "ndarray",
  "ort",
- "rubato 2.0.0",
+ "rubato",
  "rustfft",
  "thiserror 2.0.19",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,7 +39,7 @@ tauri-plugin-process = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-global-shortcut = "2"
 voice_activity_detector = { path = "vendor/voice_activity_detector" }
-rubato = "0.16"
+rubato = "2.0"
 # Pin: time 0.3.48 breaks a trait-coherence check in tauri-utils/cookie. The pre-commit hook
 # regenerates Cargo.lock (`cargo generate-lockfile`) whenever Cargo.toml changes, which would
 # otherwise keep re-bumping time to the broken release. The `=` constraint makes the pin stick.

--- a/src-tauri/src/dsp/speech.rs
+++ b/src-tauri/src/dsp/speech.rs
@@ -4,8 +4,9 @@
 //! 512-sample chunks, and reports a per-100ms-block speech decision by majority vote.
 
 use firered_vad::Vad as FireRedVad;
+use rubato::audioadapter_buffers::direct::InterleavedSlice;
 use rubato::{
-  Resampler, SincFixedIn, SincInterpolationParameters, SincInterpolationType, WindowFunction,
+  Async, FixedAsync, Resampler, SincInterpolationParameters, SincInterpolationType, WindowFunction,
 };
 use ten_vad_rs::TenVad;
 use voice_activity_detector::VoiceActivityDetector;
@@ -20,7 +21,7 @@ const VAD_CHUNK: usize = 512;
 /// TEN VAD is designed around a 256-sample hop at 16 kHz.
 const TEN_VAD_CHUNK: usize = 256;
 const TEN_VAD_MODEL: &[u8] = include_bytes!("../../vendor/ten-vad-rs/ten-vad.onnx");
-/// Mono input frames fed to the resampler per call (must be fixed for `SincFixedIn`).
+/// Mono input frames fed to the resampler per call (must be fixed for `FixedAsync::Input`).
 const RESAMPLER_IN_CHUNK: usize = 1024;
 /// Speech probability at/above which a chunk counts as speech.
 const SPEECH_THRESHOLD: f32 = 0.5;
@@ -195,7 +196,7 @@ pub fn downmix_to_mono(interleaved: &[f32], channels: u16) -> Vec<f32> {
 /// Streaming speech detector: mono samples in, per-100ms-block speech verdict out.
 pub struct SpeechDetector {
   engine: Box<dyn DialogueVadEngine>,
-  resampler: SincFixedIn<f32>,
+  resampler: Async<f32>,
   /// Mono samples at the source rate, accumulating toward `RESAMPLER_IN_CHUNK`.
   in_buf: Vec<f32>,
   /// Resampled 16 kHz samples, accumulating toward the current engine's frame size.
@@ -228,7 +229,7 @@ impl SpeechDetector {
     })
   }
 
-  fn build_resampler(source_rate: f64) -> Option<SincFixedIn<f32>> {
+  fn build_resampler(source_rate: f64) -> Option<Async<f32>> {
     let params = SincInterpolationParameters {
       sinc_len: 128,
       f_cutoff: 0.95,
@@ -236,12 +237,13 @@ impl SpeechDetector {
       interpolation: SincInterpolationType::Linear,
       window: WindowFunction::BlackmanHarris2,
     };
-    SincFixedIn::<f32>::new(
+    Async::<f32>::new_sinc(
       VAD_RATE as f64 / source_rate,
       1.0,
-      params,
+      &params,
       RESAMPLER_IN_CHUNK,
       1,
+      FixedAsync::Input,
     )
     .ok()
   }
@@ -252,9 +254,21 @@ impl SpeechDetector {
     self.in_buf.extend_from_slice(mono);
     while self.in_buf.len() >= RESAMPLER_IN_CHUNK {
       let block: Vec<f32> = self.in_buf.drain(..RESAMPLER_IN_CHUNK).collect();
-      if let Ok(out) = self.resampler.process(&[block], None) {
-        self.chunk_buf.extend_from_slice(&out[0]);
-      }
+      // rubato 1.0+ takes/returns `audioadapter` buffers instead of `Vec<Vec<f32>>`. Mono, so a
+      // single-channel interleaved view over the flat slice on both ends; the output frame count
+      // varies per call, so size the scratch to the resampler's max and keep only what it wrote.
+      let input = InterleavedSlice::new(&block[..], 1, RESAMPLER_IN_CHUNK).unwrap();
+      let max_out = self.resampler.output_frames_max();
+      let mut scratch = vec![0.0_f32; max_out];
+      let nbr_out = {
+        let mut output = InterleavedSlice::new_mut(&mut scratch[..], 1, max_out).unwrap();
+        self
+          .resampler
+          .process_into_buffer(&input, &mut output, None)
+          .map(|(_, out_frames)| out_frames)
+          .unwrap_or(0)
+      };
+      self.chunk_buf.extend_from_slice(&scratch[..nbr_out]);
       let frame_size = self.engine.frame_size();
       while self.chunk_buf.len() >= frame_size {
         let chunk: Vec<f32> = self.chunk_buf.drain(..frame_size).collect();


### PR DESCRIPTION
Supersedes #196 (Dependabot's bare `0.16 → 2.0` bump fails to compile — rubato 1.0 was a breaking API rewrite).

## What changed

rubato 1.0 merged `SincFixedIn`/`FixedOut`/`FixedInOut` into a single `Async` type with a `FixedAsync` mode, and moved `process()` from `Vec<Vec<f32>>` to `audioadapter` buffer views. The only user in this repo is the speech-VAD resampler in `src-tauri/src/dsp/speech.rs`:

- construct via `Async::new_sinc(ratio, 1.0, &params, RESAMPLER_IN_CHUNK, 1, FixedAsync::Input)`
- resample through single-channel `InterleavedSlice` views with `process_into_buffer`, sizing the output scratch to `output_frames_max()` and keeping only the frames actually written

Interpolation parameters are unchanged (sinc_len 128, f_cutoff 0.95, BlackmanHarris2), so resampling quality matches the old implementation.

## Lockfile dedupe

Bumping our direct dep to 2.0 collapses a pre-existing duplicate: `ten-vad-rs` already pulls `rubato 2.0.0` transitively, so `main` carried both `0.16.2` and `2.0.0`. The tree now has a single `rubato 2.0.0`. (Chose 2.0 over the newer 4.0 for exactly this reason — 4.0 could not dedupe while ten-vad-rs pins 2.0.)

## Verification

- `npm run check` green (266 Rust tests + VAD spike), including the `*_silence_is_not_classified_as_speech` tests that exercise the full mono→resample→VAD chain through the new resampler.
- `npm run smoke:capture` green — live capture agrees with the file path (integrated LUFS within 0.004 dB, sample peaks identical, 0 dropped).
- `npm run soak:capture` (4h) running separately — capture-layer changes are not covered by CI, and only the soak surfaces VAD-decision drift on real signal over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)