### PR TITLE
chore(deps): bump lucide-react from 1.21.0 to 1.25.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.11.3",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.17",
-        "@radix-ui/react-label": "^2.1.9",
+        "@radix-ui/react-label": "^2.1.12",
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-select": "^2.3.1",
         "@radix-ui/react-separator": "^1.1.10",
@@ -25,10 +25,11 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.40.0",
-        "lucide-react": "^1.21.0",
+        "lucide-react": "^1.25.0",
         "plvs": "file:../../..",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
+        "react-markdown": "^10.1.0",
         "tailwind-merge": "^3.6.0",
         "tw-animate-css": "^1.4.0"
       },
@@ -45,11 +46,11 @@
         "globals": "^17.7.0",
         "jsdom": "^26.1.0",
         "lint-staged": "^15.5.2",
-        "prettier": "^3.8.3",
+        "prettier": "^3.9.5",
         "sharp": "^0.35.1",
         "simple-git-hooks": "^2.13.0",
         "tailwindcss": "^4.2.4",
-        "vite": "^8.1.4",
+        "vite": "^8.1.5",
         "vitest": "^4.1.8"
       },
       "engines": {
@@ -6727,9 +6728,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
-      "integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.25.0.tgz",
+      "integrity": "sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.40.0",
-    "lucide-react": "^1.21.0",
+    "lucide-react": "^1.25.0",
     "plvs": "file:../../..",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",


### PR DESCRIPTION
Supersedes #190. Dependabot cannot update that PR — its updater can't fetch this repo's path-based dependencies (`vendor/*` crates), so it repeatedly answered `@dependabot rebase` with "couldn't fetch all your path-based dependencies". #190's branch stayed conflicted against `main`'s `package-lock.json` after the other npm bumps merged, and would never resolve on its own.

This redoes the same bump (`lucide-react` `^1.21.0` → `^1.25.0`, lockfile resolves to 1.25.0) cleanly off current `main`, so it merges without conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)